### PR TITLE
Include step-up tokens in TOTP flows and add MFA tests

### DIFF
--- a/technomoney-app/src/components/Login/Login.test.tsx
+++ b/technomoney-app/src/components/Login/Login.test.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { AuthContextType } from "../../types/auth";
+import Login from "./Login";
+
+const executeRecaptchaMock = jest.fn();
+const authApiGetMock = jest.fn();
+const authApiPostMock = jest.fn();
+const useAuthMock = jest.fn<AuthContextType, []>();
+
+jest.mock("react-google-recaptcha-v3", () => ({
+  useGoogleReCaptcha: () => ({ executeRecaptcha: executeRecaptchaMock }),
+}));
+
+jest.mock("../../services/http", () => ({
+  authApi: {
+    get: authApiGetMock,
+    post: authApiPostMock,
+    defaults: { headers: { common: {} } },
+  },
+}));
+
+jest.mock("../../context/AuthContext", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+const createContextValue = (overrides?: Partial<AuthContextType>): AuthContextType => ({
+  token: null,
+  username: null,
+  login: jest.fn().mockResolvedValue(undefined),
+  logout: jest.fn().mockResolvedValue(undefined),
+  isAuthenticated: false,
+  loading: false,
+  fetchWithAuth: jest.fn(),
+  connected: false,
+  lastEvent: null,
+  connectEvents: jest.fn().mockResolvedValue(undefined),
+  webauthnRegister: jest.fn().mockResolvedValue(false),
+  webauthnAuthenticate: jest.fn().mockResolvedValue(false),
+  stepUpRequirement: null,
+  setStepUpRequirement: jest.fn(),
+  ...overrides,
+});
+
+describe("Login step-up handling", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    executeRecaptchaMock.mockResolvedValue("captcha-token");
+    authApiGetMock.mockResolvedValue({ data: { csrfToken: "csrf" } });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  it("uses the provided token when enrolling TOTP is required", async () => {
+    const loginFn = jest.fn().mockResolvedValue(undefined);
+    useAuthMock.mockReturnValue(createContextValue({ login: loginFn }));
+    const error = {
+      response: {
+        data: {
+          stepUp: "enroll_totp",
+          token: "jwt-token",
+          username: "Neo",
+        },
+      },
+    };
+    authApiPostMock.mockImplementation((url: string) => {
+      if (url === "auth/login") return Promise.reject(error);
+      return Promise.resolve({ data: {} });
+    });
+
+    render(<Login />);
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    fireEvent.change(screen.getByLabelText(/E-mail/i), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/Senha/i), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Entrar/i }));
+
+    await waitFor(() => {
+      expect(loginFn).toHaveBeenCalledWith("jwt-token", "Neo");
+    });
+
+    expect(
+      screen.getByText(/Habilitar autenticação em duas etapas/i)
+    ).toBeInTheDocument();
+  });
+
+  it("uses the provided token when a TOTP challenge is required", async () => {
+    const loginFn = jest.fn().mockResolvedValue(undefined);
+    useAuthMock.mockReturnValue(createContextValue({ login: loginFn }));
+    const error = {
+      response: {
+        data: {
+          stepUp: "totp",
+          token: "jwt-token",
+          username: "Trinity",
+        },
+      },
+    };
+    authApiPostMock.mockImplementation((url: string) => {
+      if (url === "auth/login") return Promise.reject(error);
+      return Promise.resolve({ data: {} });
+    });
+
+    render(<Login />);
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    fireEvent.change(screen.getByLabelText(/E-mail/i), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/Senha/i), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Entrar/i }));
+
+    await waitFor(() => {
+      expect(loginFn).toHaveBeenCalledWith("jwt-token", "Trinity");
+    });
+
+    expect(
+      screen.getByText(/Confirme o código do autenticador/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/technomoney-app/src/components/Login/TotpChallenge.test.tsx
+++ b/technomoney-app/src/components/Login/TotpChallenge.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { AuthContextType } from "../../types/auth";
+import TotpChallenge from "./TotpChallenge";
+
+const useAuthMock = jest.fn<AuthContextType, []>();
+
+jest.mock("../../context/AuthContext", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+describe("TotpChallenge", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("verifies the challenge and reuses the provided token", async () => {
+    const fetchWithAuth = jest.fn().mockResolvedValue({
+      data: { token: "new-token", acr: "aal2" },
+    });
+    const login = jest.fn().mockResolvedValue(undefined);
+    const onSuccess = jest.fn();
+    const setStepUpRequirement = jest.fn();
+    useAuthMock.mockReturnValue({
+      token: "jwt-token",
+      username: "Neo",
+      login,
+      logout: jest.fn(),
+      isAuthenticated: false,
+      loading: false,
+      fetchWithAuth,
+      connected: false,
+      lastEvent: null,
+      connectEvents: jest.fn(),
+      webauthnRegister: jest.fn(),
+      webauthnAuthenticate: jest.fn(),
+      stepUpRequirement: null,
+      setStepUpRequirement,
+    });
+
+    render(<TotpChallenge onSuccess={onSuccess} />);
+
+    const input = screen.getByLabelText(/Código de 6 dígitos/i);
+    fireEvent.change(input, { target: { value: "654321" } });
+    fireEvent.submit(input.closest("form")!);
+
+    await waitFor(() => {
+      expect(fetchWithAuth).toHaveBeenCalledWith(
+        "/api/auth/totp/challenge/verify",
+        expect.objectContaining({
+          method: "POST",
+          data: { code: "654321" },
+        })
+      );
+    });
+
+    expect(login).toHaveBeenCalledWith("new-token", "Neo");
+    expect(setStepUpRequirement).toHaveBeenCalledWith(null);
+    expect(onSuccess).toHaveBeenCalledWith({ token: "new-token", acr: "aal2" });
+  });
+});

--- a/technomoney-app/src/components/Login/TotpEnrollment.test.tsx
+++ b/technomoney-app/src/components/Login/TotpEnrollment.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { AuthContextType } from "../../types/auth";
+import TotpEnrollment from "./TotpEnrollment";
+
+const useAuthMock = jest.fn<AuthContextType, []>();
+
+jest.mock("../../context/AuthContext", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+describe("TotpEnrollment", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("walks through the enrollment flow using the existing session token", async () => {
+    const fetchWithAuth = jest
+      .fn()
+      .mockResolvedValueOnce({ data: { enrolled: false } })
+      .mockResolvedValueOnce({
+        data: { qrDataUrl: "data:image/png;base64,QR", secret: "SECRET" },
+      })
+      .mockResolvedValueOnce({ data: {} });
+    const onCompleted = jest.fn();
+    useAuthMock.mockReturnValue({
+      token: "jwt-token",
+      username: "Neo",
+      login: jest.fn(),
+      logout: jest.fn(),
+      isAuthenticated: false,
+      loading: false,
+      fetchWithAuth,
+      connected: false,
+      lastEvent: null,
+      connectEvents: jest.fn(),
+      webauthnRegister: jest.fn(),
+      webauthnAuthenticate: jest.fn(),
+      stepUpRequirement: null,
+      setStepUpRequirement: jest.fn(),
+    });
+
+    render(<TotpEnrollment onCompleted={onCompleted} />);
+
+    await waitFor(() => {
+      expect(fetchWithAuth).toHaveBeenCalledWith("/api/auth/totp/status");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Gerar QR Code/i }));
+
+    await waitFor(() => {
+      expect(fetchWithAuth).toHaveBeenCalledWith(
+        "/api/auth/totp/setup/start",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    const codeInput = await screen.findByLabelText(/Código de 6 dígitos/i);
+    fireEvent.change(codeInput, { target: { value: "123456" } });
+
+    await act(async () => {
+      fireEvent.submit(codeInput.closest("form")!);
+    });
+
+    await waitFor(() => {
+      expect(fetchWithAuth).toHaveBeenCalledWith(
+        "/api/auth/totp/setup/verify",
+        expect.objectContaining({
+          method: "POST",
+          data: { code: "123456" },
+        })
+      );
+    });
+
+    expect(onCompleted).toHaveBeenCalled();
+  });
+});

--- a/technomoney-app/src/context/AuthContext.test.tsx
+++ b/technomoney-app/src/context/AuthContext.test.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect } from "react";
+import { act, render, waitFor } from "@testing-library/react";
+import type { AuthContextType } from "../types/auth";
+import { AuthProvider, useAuth } from "./AuthContext";
+
+const postMock = jest.fn();
+const getMock = jest.fn();
+const requestMock = jest.fn();
+const setAuthTokenGetterMock = jest.fn();
+
+jest.mock("../services/http", () => ({
+  authApi: {
+    post: postMock,
+    get: getMock,
+    request: requestMock,
+    defaults: { headers: { common: {} } },
+  },
+  setAuthTokenGetter: setAuthTokenGetterMock,
+}));
+
+class MockWebSocket {
+  public static instances: MockWebSocket[] = [];
+  public onopen: ((ev?: any) => void) | null = null;
+  public onclose: ((ev: any) => void) | null = null;
+  public onmessage: ((ev: any) => void) | null = null;
+  public close = jest.fn();
+  public send = jest.fn();
+  constructor(public url: string, public protocol?: string) {
+    MockWebSocket.instances.push(this);
+  }
+}
+
+(global as any).WebSocket = MockWebSocket as unknown as typeof WebSocket;
+
+const Consumer: React.FC<{ onReady: (ctx: AuthContextType) => void }> = ({
+  onReady,
+}) => {
+  const ctx = useAuth();
+  useEffect(() => {
+    if (!ctx.loading) onReady(ctx);
+  }, [ctx, onReady]);
+  return null;
+};
+
+describe("AuthContext", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    postMock.mockImplementation((url: string) => {
+      if (url === "/auth/refresh") {
+        return Promise.reject({ response: { status: 401 } });
+      }
+      if (url === "/auth/ws-ticket") {
+        return Promise.resolve({
+          data: { ticket: "ticket", sid: "sid", wsUrl: "ws://localhost" },
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+    requestMock.mockResolvedValue({ data: {} });
+  });
+
+  it("stores the token provided during login and reuses it for authenticated calls", async () => {
+    let latestContext: AuthContextType | null = null;
+    const onReady = jest.fn((ctx: AuthContextType) => {
+      latestContext = ctx;
+    });
+
+    render(
+      <AuthProvider>
+        <Consumer onReady={onReady} />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(onReady).toHaveBeenCalled();
+      expect(latestContext).not.toBeNull();
+      expect(latestContext!.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await latestContext!.login("jwt-token", "Neo");
+    });
+
+    await waitFor(() => {
+      expect(latestContext!.token).toBe("jwt-token");
+    });
+
+    const refreshCallsBefore = postMock.mock.calls.filter(
+      ([url]) => url === "/auth/refresh"
+    ).length;
+
+    await act(async () => {
+      await latestContext!.fetchWithAuth("/api/auth/totp/status");
+    });
+
+    const refreshCallsAfter = postMock.mock.calls.filter(
+      ([url]) => url === "/auth/refresh"
+    ).length;
+
+    expect(refreshCallsAfter).toBe(refreshCallsBefore);
+    expect(requestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "/api/auth/totp/status",
+        headers: expect.objectContaining({
+          Authorization: "Bearer jwt-token",
+        }),
+      })
+    );
+  });
+});

--- a/technomoney-app/tsconfig.json
+++ b/technomoney-app/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,            
     "jsx": "react-jsx",                   
-    "types": ["vite/client"]
+    "types": ["vite/client", "jest"]
   },
   "include": ["src", "vite-env.d.ts"],
   "noEmit": true

--- a/technomoney-auth/package.json
+++ b/technomoney-auth/package.json
@@ -7,7 +7,7 @@
     "build": "tsc -p tsconfig.json",
     "start": "node scripts/with-totp-key.cjs node dist/server.js",
     "dev": "node scripts/with-totp-key.cjs nodemon",
-    "test": "node scripts/with-totp-key.cjs npm run build"
+    "test": "node scripts/with-totp-key.cjs node scripts/run-tests.cjs"
   },
   "keywords": [],
   "author": "",

--- a/technomoney-auth/scripts/run-tests.cjs
+++ b/technomoney-auth/scripts/run-tests.cjs
@@ -1,0 +1,33 @@
+const { spawn } = require("child_process");
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: "inherit",
+      env: { ...process.env, ...options.env },
+      shell: process.platform === "win32",
+    });
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`Command ${command} ${args.join(" ")} terminated by signal ${signal}`));
+        return;
+      }
+      if (code !== 0) {
+        reject(new Error(`Command ${command} ${args.join(" ")} exited with code ${code}`));
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+(async () => {
+  const env = {
+    TS_NODE_TRANSPILE_ONLY: "1",
+    TS_NODE_FILES: "1",
+  };
+  await run("node", ["--test", "-r", "ts-node/register", "src/controllers/__tests__/auth.controller.spec.ts"], {
+    env,
+  });
+})();

--- a/technomoney-auth/src/controllers/__tests__/auth.controller.spec.ts
+++ b/technomoney-auth/src/controllers/__tests__/auth.controller.spec.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Request, Response } from "express";
+
+const stubModule = (specifier: string, exports: unknown) => {
+  const resolved = require.resolve(specifier);
+  require.cache[resolved] = {
+    id: resolved,
+    filename: resolved,
+    loaded: true,
+    exports,
+  } as any;
+};
+
+stubModule("../../utils/log/logger", {
+  logger: {
+    info: () => {},
+    error: () => {},
+    warn: () => {},
+    child: () => ({ info: () => {}, error: () => {}, warn: () => {} }),
+  },
+});
+
+stubModule("../../ws", {
+  deriveSid: () => "sid",
+  publishToSid: () => {},
+  publishToUser: () => {},
+  scheduleTokenExpiringSoon: () => {},
+  clearSessionSchedules: () => {},
+});
+
+stubModule("../../services/trusted-device.service", {
+  getTrustedDevice: async () => null,
+});
+
+type MockResponse = Response & {
+  statusCalls: Array<[number]>;
+  jsonCalls: Array<[unknown]>;
+};
+
+type LoginResult = {
+  access: string;
+  refresh: string;
+  username?: string | null;
+};
+
+const createJwt = (payload: Record<string, unknown>): string => {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString(
+    "base64url"
+  );
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.sig`;
+};
+
+const makeResponse = (): MockResponse => {
+  const statusCalls: Array<[number]> = [];
+  const jsonCalls: Array<[unknown]> = [];
+  const res = {
+    status(code: number) {
+      statusCalls.push([code]);
+      return this;
+    },
+    json(payload: unknown) {
+      jsonCalls.push([payload]);
+      return this;
+    },
+    cookie() {
+      return this;
+    },
+    statusCalls,
+    jsonCalls,
+  };
+  return res as unknown as MockResponse;
+};
+
+type AuthServiceStub = {
+  loginCalls: Array<[string, string]>;
+  logoutCalls: Array<[string]>;
+  loginResult: LoginResult;
+} & {
+  login(email: string, password: string): Promise<LoginResult>;
+  logout(refresh: string): Promise<void>;
+  register(): Promise<never>;
+  refresh(): Promise<never>;
+};
+
+type TotpServiceStub = {
+  statusCalls: Array<[string]>;
+  statusResult: boolean;
+} & {
+  status(userId: string): Promise<boolean>;
+};
+
+type TrustedDeviceStub = {
+  result: any;
+  calls: Array<[unknown]>;
+} & ((req: unknown) => Promise<any>);
+
+const createAuthServiceStub = (result: LoginResult): AuthServiceStub => {
+  const stub: AuthServiceStub = {
+    loginCalls: [],
+    logoutCalls: [],
+    loginResult: result,
+    async login(email: string, password: string) {
+      stub.loginCalls.push([email, password]);
+      return stub.loginResult;
+    },
+    async logout(refresh: string) {
+      stub.logoutCalls.push([refresh]);
+    },
+    async register() {
+      throw new Error("not used");
+    },
+    async refresh() {
+      throw new Error("not used");
+    },
+  } as AuthServiceStub;
+  return stub;
+};
+
+const createTotpServiceStub = (statusResult: boolean): TotpServiceStub => {
+  const stub: TotpServiceStub = {
+    statusCalls: [],
+    statusResult,
+    async status(userId: string) {
+      stub.statusCalls.push([userId]);
+      return stub.statusResult;
+    },
+  } as TotpServiceStub;
+  return stub;
+};
+
+const createTrustedDeviceStub = (value: any): TrustedDeviceStub => {
+  const fn = (async (req: unknown) => {
+    fn.calls.push([req]);
+    return fn.result;
+  }) as TrustedDeviceStub;
+  fn.result = value;
+  fn.calls = [];
+  return fn;
+};
+
+test("login returns enroll_totp step-up with issued token", async (t) => {
+  process.env.AUTH_CONTROLLER_SKIP_DEFAULT = "1";
+  const controller = await import("../auth.controller");
+  const authService = createAuthServiceStub({
+    access: createJwt({
+      sub: "user-123",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    }),
+    refresh: "refresh-token",
+    username: "Neo",
+  });
+  const totpService = createTotpServiceStub(false);
+  const trustedDevice = createTrustedDeviceStub(null);
+  controller.__setAuthControllerDeps({
+    authService,
+    totpService,
+    getTrustedDevice: trustedDevice,
+  });
+  t.after(() => {
+    controller.__resetAuthControllerDeps();
+  });
+  const req = {
+    body: { email: "user@example.com", password: "secret" },
+  } as Request;
+  const res = makeResponse();
+
+  await controller.login(req, res as Response, (() => {}) as any);
+
+  assert.strictEqual(authService.loginCalls.length, 1);
+  assert.strictEqual(authService.logoutCalls.length, 1);
+  assert.deepStrictEqual(authService.logoutCalls[0], ["refresh-token"]);
+  assert.strictEqual(totpService.statusCalls.length, 1);
+  assert.strictEqual(res.statusCalls.length, 1);
+  assert.deepStrictEqual(res.statusCalls[0], [401]);
+  assert.strictEqual(res.jsonCalls.length, 1);
+  assert.deepStrictEqual(res.jsonCalls[0][0], {
+    stepUp: "enroll_totp",
+    token: authService.loginResult.access,
+    username: "Neo",
+  });
+});
+
+test("login returns totp step-up with issued token", async (t) => {
+  process.env.AUTH_CONTROLLER_SKIP_DEFAULT = "1";
+  const controller = await import("../auth.controller");
+  const authService = createAuthServiceStub({
+    access: createJwt({
+      sub: "user-123",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    }),
+    refresh: "refresh-token",
+    username: "Trinity",
+  });
+  const totpService = createTotpServiceStub(true);
+  const trustedDevice = createTrustedDeviceStub(null);
+  controller.__setAuthControllerDeps({
+    authService,
+    totpService,
+    getTrustedDevice: trustedDevice,
+  });
+  t.after(() => {
+    controller.__resetAuthControllerDeps();
+  });
+  const req = {
+    body: { email: "user@example.com", password: "secret" },
+  } as Request;
+  const res = makeResponse();
+
+  await controller.login(req, res as Response, (() => {}) as any);
+
+  assert.strictEqual(authService.loginCalls.length, 1);
+  assert.strictEqual(authService.logoutCalls.length, 1);
+  assert.deepStrictEqual(authService.logoutCalls[0], ["refresh-token"]);
+  assert.strictEqual(totpService.statusCalls.length, 1);
+  assert.strictEqual(res.statusCalls.length, 1);
+  assert.deepStrictEqual(res.statusCalls[0], [401]);
+  assert.strictEqual(res.jsonCalls.length, 1);
+  assert.deepStrictEqual(res.jsonCalls[0][0], {
+    stepUp: "totp",
+    token: authService.loginResult.access,
+    username: "Trinity",
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the login controller includes the issued access token and username in step-up responses while keeping refresh tokens revoked
- add injectable hooks and a Node-based test suite that validates the new controller payloads without requiring the full build
- add front-end tests for the login step-up flow, AuthContext token reuse, and TOTP enrollment/challenge components
- expose jest types to the Vite TypeScript setup so the new UI tests compile

## Testing
- `npm test` (technomoney-auth)
- `CI=true npm test -- --watchAll=false` *(fails: react-scripts not available in this environment)* (technomoney-app)


------
https://chatgpt.com/codex/tasks/task_b_68cc8d6f6eac832fb3135a7673dff31a