### PR TITLE
Handle 401 refresh for dashboard requests

### DIFF
--- a/technomoney-app/src/components/Dashboard/Dashboard.test.tsx
+++ b/technomoney-app/src/components/Dashboard/Dashboard.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import {
+  QueryClient,
+  QueryClientProvider,
+  setLogger,
+} from "@tanstack/react-query";
+import Dashboard from "./Dashboard";
+import { fetchApiWithAuth, setAuthRefreshHandler } from "../../services/http";
+
+jest.mock("../../context/AuthContext", () => ({
+  useAuth: () => ({ token: "token" }),
+}));
+
+jest.mock("../../services/http", () => {
+  const requestMock = jest.fn();
+  let refreshHandler: (() => Promise<string | null>) | null = null;
+  const fetchApiWithAuth = jest.fn(async (url: string, config?: any) => {
+    try {
+      return await requestMock(url, config);
+    } catch (err: any) {
+      if (err?.response?.status === 401 && refreshHandler) {
+        const refreshed = await refreshHandler();
+        if (!refreshed) throw err;
+        return await requestMock(url, config);
+      }
+      throw err;
+    }
+  });
+  (fetchApiWithAuth as any).__requestMock = requestMock;
+  return {
+    fetchApiWithAuth,
+    setAuthRefreshHandler: jest.fn((handler) => {
+      refreshHandler = handler;
+    }),
+    setAuthTokenGetter: jest.fn(),
+    authApi: {
+      post: jest.fn(),
+      get: jest.fn(),
+      request: jest.fn(),
+      defaults: { headers: { common: {} } },
+    },
+  };
+});
+
+describe("Dashboard", () => {
+  beforeAll(() => {
+    setLogger({ log: () => {}, warn: () => {}, error: () => {} });
+  });
+
+  it("recovers the assets list after refreshing the token on a 401 response", async () => {
+    const refreshMock = jest.fn().mockResolvedValue("new-token");
+    setAuthRefreshHandler(refreshMock);
+
+    const requestMock = (fetchApiWithAuth as any)
+      .__requestMock as jest.Mock;
+    requestMock.mockRejectedValueOnce({ response: { status: 401 } });
+    requestMock.mockResolvedValueOnce({
+      data: [
+        {
+          id: 1,
+          tag: "ABC",
+          nome: "Acao ABC",
+          preco: 10,
+          variacao: 1,
+          volume: 100,
+        },
+      ],
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Dashboard />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(refreshMock).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Total de Ações")).toBeInTheDocument();
+    });
+
+    expect(requestMock).toHaveBeenCalledTimes(2);
+
+    queryClient.clear();
+  });
+});

--- a/technomoney-app/src/components/Dashboard/Dashboard.tsx
+++ b/technomoney-app/src/components/Dashboard/Dashboard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useQuery } from "@tanstack/react-query";
-import { api } from "../../services/http";
+import { useAuth } from "../../context/AuthContext";
+import { fetchApiWithAuth } from "../../services/http";
 import RealTimeActions from "../Dashboard/RealTimeActions/RealTimeActions";
 import ActionsTable from "../Dashboard/ActionsTable/ActionsTable";
 import ActionsAnalysis from "../Dashboard/ActionsAnalysis/ActionsAnalysis";
@@ -33,9 +34,9 @@ async function fetchAssets({
 }: {
   signal?: AbortSignal;
 }): Promise<AssetsResult> {
-  const token = localStorage.getItem("access");
-  if (!token) throw new Error("Token não encontrado. Faça login.");
-  const { data } = await api.get<Acao[]>("/assets/sorted/price", { signal });
+  const { data } = await fetchApiWithAuth<Acao[]>("/assets/sorted/price", {
+    signal,
+  });
   const acoes = Array.isArray(data) ? data : [];
   const maiorPreco = acoes.length ? acoes[0] : null;
   const menorPreco = acoes.length ? acoes[acoes.length - 1] : null;
@@ -46,8 +47,7 @@ async function fetchAssets({
 }
 
 const Dashboard: React.FC = () => {
-  const token =
-    typeof window !== "undefined" ? localStorage.getItem("access") : null;
+  const { token } = useAuth();
 
   const { data, isLoading, error } = useQuery<AssetsResult, Error>({
     queryKey: ["assetsSortedByPrice", token],

--- a/technomoney-app/src/context/AuthContext.test.tsx
+++ b/technomoney-app/src/context/AuthContext.test.tsx
@@ -7,6 +7,7 @@ const postMock = jest.fn();
 const getMock = jest.fn();
 const requestMock = jest.fn();
 const setAuthTokenGetterMock = jest.fn();
+const setAuthRefreshHandlerMock = jest.fn();
 
 jest.mock("../services/http", () => ({
   authApi: {
@@ -16,6 +17,7 @@ jest.mock("../services/http", () => ({
     defaults: { headers: { common: {} } },
   },
   setAuthTokenGetter: setAuthTokenGetterMock,
+  setAuthRefreshHandler: setAuthRefreshHandlerMock,
 }));
 
 class MockWebSocket {
@@ -45,6 +47,7 @@ const Consumer: React.FC<{ onReady: (ctx: AuthContextType) => void }> = ({
 describe("AuthContext", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    setAuthRefreshHandlerMock.mockClear();
     postMock.mockImplementation((url: string) => {
       if (url === "/auth/refresh") {
         return Promise.reject({ response: { status: 401 } });
@@ -71,6 +74,9 @@ describe("AuthContext", () => {
       </AuthProvider>
     );
 
+    await waitFor(() => {
+      expect(setAuthRefreshHandlerMock).toHaveBeenCalled();
+    });
     await waitFor(() => {
       expect(onReady).toHaveBeenCalled();
       expect(latestContext).not.toBeNull();

--- a/technomoney-app/src/context/AuthContext.tsx
+++ b/technomoney-app/src/context/AuthContext.tsx
@@ -8,7 +8,7 @@ import React, {
   useCallback,
 } from "react";
 import type { AxiosRequestConfig, AxiosResponse } from "axios";
-import { authApi, setAuthTokenGetter } from "../services/http";
+import { authApi, setAuthRefreshHandler, setAuthTokenGetter } from "../services/http";
 import type {
   AuthContextType,
   AuthEvent,
@@ -321,6 +321,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       setAuthTokenGetter(null);
     };
   }, []);
+
+  useEffect(() => {
+    setAuthRefreshHandler(refreshToken);
+    return () => {
+      setAuthRefreshHandler(null);
+    };
+  }, [refreshToken]);
 
   const value = useMemo<AuthContextType>(
     () => ({


### PR DESCRIPTION
## Summary
- add shared refresh-token callback handling to the HTTP service and expose a helper for authenticated API requests
- register the refresh callback from the auth context and consume the helper inside the dashboard query
- add unit tests covering the 401 → refresh → retry flow for the dashboard listing and adjust existing auth context tests

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found because dependencies are unavailable in the environment)*
- `npm install` *(fails: npm registry access is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cca2137994832f8d15bbcd1943a0ea