### PR TITLE
Implement MFA step-up token flow

### DIFF
--- a/technomoney-api/src/middlewares/auth.middleware.ts
+++ b/technomoney-api/src/middlewares/auth.middleware.ts
@@ -1,6 +1,15 @@
 import { JwtVerifierService } from "../services/jwt-verifier.service";
 import { logger } from "../utils/logger";
 const verifier = new JwtVerifierService();
+
+const normalizeScope = (scope: string[] | string): string[] => {
+  if (Array.isArray(scope)) return scope;
+  return String(scope || "")
+    .split(" ")
+    .map((s) => s.trim())
+    .filter(Boolean);
+};
+
 export const authenticate = async (req: any, res: any, next: any) => {
   try {
     const h = String(req.headers.authorization || "");
@@ -14,7 +23,31 @@ export const authenticate = async (req: any, res: any, next: any) => {
       return;
     }
     const { id, jti, scope, payload } = await verifier.verifyAccess(token);
-    req.user = { id, jti, scope, payload };
+    const scopeList = normalizeScope(scope);
+    const acr = typeof (payload as any).acr === "string" ? (payload as any).acr : undefined;
+    if (acr === "step-up" || scopeList.includes("auth:stepup")) {
+      res.setHeader(
+        "WWW-Authenticate",
+        'Bearer realm="api", error="insufficient_aal", error_description="Step-up token not allowed"'
+      );
+      res.status(401).json({ message: "Step-up token requires MFA" });
+      return;
+    }
+    const username =
+      typeof (payload as any).username === "string"
+        ? (payload as any).username
+        : typeof (payload as any).preferred_username === "string"
+        ? (payload as any).preferred_username
+        : undefined;
+    req.user = {
+      id,
+      jti,
+      scope: scopeList,
+      payload,
+      acr,
+      username,
+      exp: typeof (payload as any).exp === "number" ? (payload as any).exp : undefined,
+    };
     next();
   } catch (e: any) {
     logger.debug({ err: String(e) }, "auth.middleware.denied");

--- a/technomoney-api/src/middlewares/requireAAL2.middleware.ts
+++ b/technomoney-api/src/middlewares/requireAAL2.middleware.ts
@@ -1,0 +1,10 @@
+import type { Request, Response, NextFunction } from "express";
+
+export const requireAAL2 = (req: Request, res: Response, next: NextFunction) => {
+  const user = req.user as { acr?: string } | undefined;
+  if (user?.acr === "aal2") {
+    next();
+    return;
+  }
+  res.status(401).json({ stepUp: "totp" });
+};

--- a/technomoney-api/src/routes/assetRoutes.ts
+++ b/technomoney-api/src/routes/assetRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authenticate } from "../middlewares/auth.middleware";
 import { requireDPoPIfBound } from "../middlewares/dpop.middleware";
+import { requireAAL2 } from "../middlewares/requireAAL2.middleware";
 import {
   createAsset,
   getAllAssets,
@@ -13,7 +14,7 @@ const assetRouter = Router();
 
 assetRouter.use(authenticate, requireDPoPIfBound);
 
-assetRouter.post("/assets", createAsset);
+assetRouter.post("/assets", requireAAL2, createAsset);
 assetRouter.get("/assets", getAllAssets);
 assetRouter.get("/assets/sorted/volume", getAssetsSortedByVolume);
 assetRouter.get("/assets/sorted/price", getAssetsSortedByPrice);

--- a/technomoney-app/src/components/Login/Login.test.tsx
+++ b/technomoney-app/src/components/Login/Login.test.tsx
@@ -63,6 +63,7 @@ describe("Login step-up handling", () => {
           stepUp: "enroll_totp",
           token: "jwt-token",
           username: "Neo",
+          acr: "step-up",
         },
       },
     };
@@ -85,7 +86,11 @@ describe("Login step-up handling", () => {
     fireEvent.click(screen.getByRole("button", { name: /Entrar/i }));
 
     await waitFor(() => {
-      expect(loginFn).toHaveBeenCalledWith("jwt-token", "Neo");
+      expect(loginFn).toHaveBeenCalledWith("jwt-token", "Neo", {
+        stepUp: true,
+        acr: "step-up",
+        source: "login",
+      });
     });
 
     expect(
@@ -102,6 +107,7 @@ describe("Login step-up handling", () => {
           stepUp: "totp",
           token: "jwt-token",
           username: "Trinity",
+          acr: "step-up",
         },
       },
     };
@@ -124,7 +130,11 @@ describe("Login step-up handling", () => {
     fireEvent.click(screen.getByRole("button", { name: /Entrar/i }));
 
     await waitFor(() => {
-      expect(loginFn).toHaveBeenCalledWith("jwt-token", "Trinity");
+      expect(loginFn).toHaveBeenCalledWith("jwt-token", "Trinity", {
+        stepUp: true,
+        acr: "step-up",
+        source: "login",
+      });
     });
 
     expect(

--- a/technomoney-app/src/components/Login/Login.tsx
+++ b/technomoney-app/src/components/Login/Login.tsx
@@ -77,7 +77,11 @@ const Login: React.FC = () => {
     if (step !== "enroll_totp" && step !== "totp") return;
     const usernameHint = data?.username ?? null;
     if (data?.token) {
-      await login(data.token, usernameHint);
+      await login(data.token, usernameHint, {
+        stepUp: true,
+        acr: data?.acr ?? null,
+        source: "login",
+      });
     }
     setStepUp({ mode: step, usernameHint });
     setError("");
@@ -147,20 +151,20 @@ const Login: React.FC = () => {
   };
 
   const handleChallengeSuccess = async () => {
+    setStepUpProcessing(true);
     try {
-      setStepUpProcessing(true);
-      await performLogin();
+      setStepUp(null);
+      navigate("/dashboard");
     } finally {
       setStepUpProcessing(false);
     }
   };
 
-  const handleEnrollmentCompleted = async () => {
+  const handleEnrollmentCompleted = () => {
     setStepUp((prev) => ({
       mode: "totp",
       usernameHint: prev?.usernameHint ?? null,
     }));
-    await handleChallengeSuccess();
   };
 
   if (loadingSpinner) return <Spinner />;

--- a/technomoney-app/src/components/Login/TotpChallenge.test.tsx
+++ b/technomoney-app/src/components/Login/TotpChallenge.test.tsx
@@ -46,7 +46,7 @@ describe("TotpChallenge", () => {
 
     await waitFor(() => {
       expect(fetchWithAuth).toHaveBeenCalledWith(
-        "/api/auth/totp/challenge/verify",
+        "/totp/challenge/verify",
         expect.objectContaining({
           method: "POST",
           data: { code: "654321" },
@@ -56,6 +56,8 @@ describe("TotpChallenge", () => {
 
     expect(login).toHaveBeenCalledWith("new-token", "Neo");
     expect(setStepUpRequirement).toHaveBeenCalledWith(null);
-    expect(onSuccess).toHaveBeenCalledWith({ token: "new-token", acr: "aal2" });
+    expect(onSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({ token: "new-token", acr: "aal2" })
+    );
   });
 });

--- a/technomoney-app/src/components/Login/TotpChallenge.tsx
+++ b/technomoney-app/src/components/Login/TotpChallenge.tsx
@@ -1,11 +1,14 @@
 import React, { useState } from "react";
 import { useAuth } from "../../context/AuthContext";
 
+type TotpChallengeResult = {
+  token: string;
+  acr?: string | null;
+  username?: string | null;
+};
+
 type TotpChallengeProps = {
-  onSuccess?: (result: {
-    token: string;
-    acr?: string | null;
-  }) => void | Promise<void>;
+  onSuccess?: (result: TotpChallengeResult) => void | Promise<void>;
   onCancel?: () => void;
   title?: string;
   message?: React.ReactNode;
@@ -38,9 +41,11 @@ const TotpChallenge: React.FC<TotpChallengeProps> = ({
         method: "POST",
         data: { code },
       });
-      const data = res.data as { token: string; acr?: string | null };
+      const data = res.data as TotpChallengeResult;
+      const nextUsername =
+        typeof data?.username === "string" ? data.username : username;
       if (data?.token) {
-        await login(data.token, username);
+        await login(data.token, nextUsername ?? null);
       }
       setCode("");
       if (setStepUpRequirement) setStepUpRequirement(null);

--- a/technomoney-app/src/components/Login/TotpEnrollment.test.tsx
+++ b/technomoney-app/src/components/Login/TotpEnrollment.test.tsx
@@ -43,14 +43,14 @@ describe("TotpEnrollment", () => {
     render(<TotpEnrollment onCompleted={onCompleted} />);
 
     await waitFor(() => {
-      expect(fetchWithAuth).toHaveBeenCalledWith("/api/auth/totp/status");
+      expect(fetchWithAuth).toHaveBeenCalledWith("/totp/status");
     });
 
     fireEvent.click(screen.getByRole("button", { name: /Gerar QR Code/i }));
 
     await waitFor(() => {
       expect(fetchWithAuth).toHaveBeenCalledWith(
-        "/api/auth/totp/setup/start",
+        "/totp/setup/start",
         expect.objectContaining({ method: "POST" })
       );
     });
@@ -64,7 +64,7 @@ describe("TotpEnrollment", () => {
 
     await waitFor(() => {
       expect(fetchWithAuth).toHaveBeenCalledWith(
-        "/api/auth/totp/setup/verify",
+        "/totp/setup/verify",
         expect.objectContaining({
           method: "POST",
           data: { code: "123456" },

--- a/technomoney-app/src/types/auth.ts
+++ b/technomoney-app/src/types/auth.ts
@@ -37,10 +37,17 @@ export interface MeResponse {
   exp: number;
 }
 
+export interface LoginOptions {
+  stepUp?: boolean;
+  acr?: string | null;
+  scope?: string[] | null;
+  source?: StepUpRequirement["source"];
+}
+
 export interface AuthContextType {
   token: string | null;
   username: string | null;
-  login: (token: string, username: string | null) => Promise<void>;
+  login: (token: string, username: string | null, options?: LoginOptions) => Promise<void>;
   logout: () => Promise<void>;
   isAuthenticated: boolean;
   loading: boolean;

--- a/technomoney-auth/src/controllers/totp.controller.ts
+++ b/technomoney-auth/src/controllers/totp.controller.ts
@@ -1,16 +1,20 @@
 import { RequestHandler } from "express";
 import { TotpService } from "../services/totp.service";
-import { JwtService } from "../services/jwt.service";
 import { setTrustedDevice } from "../services/trusted-device.service";
 import { resetTotpLimiter } from "../middlewares/totpLimiter.middleware";
 import QRCode from "qrcode";
+import jwt from "jsonwebtoken";
+import { AuthService } from "../services/auth.service";
+import { buildRefreshCookie } from "../utils/cookie.util";
+import { deriveSid, scheduleTokenExpiringSoon } from "../ws";
 
 const svc = new TotpService();
-const jwt = new JwtService();
+const auth = new AuthService();
+const cookieOpts = buildRefreshCookie();
 
 export const status: RequestHandler = async (req: any, res) => {
-  const u = req.user as { id: string } | undefined;
-  if (!u) {
+  const u = req.user as { id: string; acr?: string; scope?: string[] } | undefined;
+  if (!u || !isStepUpContext(u)) {
     res.status(401).json({ message: "Unauthorized" });
     return;
   }
@@ -20,21 +24,32 @@ export const status: RequestHandler = async (req: any, res) => {
 
 export const setupStart: RequestHandler = async (req: any, res) => {
   const u = req.user as
-    | { id: string; username?: string; email?: string }
+    | {
+        id: string;
+        username?: string;
+        email?: string;
+        acr?: string;
+        scope?: string[];
+        token?: string;
+      }
     | undefined;
-  if (!u) {
+  if (!u || !isStepUpContext(u)) {
     res.status(401).json({ message: "Unauthorized" });
     return;
   }
-  const label = u.email || u.username || u.id;
+  const label =
+    u.email ||
+    u.username ||
+    extractUsername(u.token) ||
+    u.id;
   const data = await svc.setupStart(u.id, label);
   const qrDataUrl = await QRCode.toDataURL(data.otpauth);
   res.json({ secret: data.secret, otpauth: data.otpauth, qrDataUrl });
 };
 
 export const setupVerify: RequestHandler = async (req: any, res) => {
-  const u = req.user as { id: string } | undefined;
-  if (!u) {
+  const u = req.user as { id: string; acr?: string; scope?: string[] } | undefined;
+  if (!u || !isStepUpContext(u)) {
     res.status(401).json({ message: "Unauthorized" });
     return;
   }
@@ -48,8 +63,8 @@ export const setupVerify: RequestHandler = async (req: any, res) => {
 };
 
 export const challengeVerify: RequestHandler = async (req: any, res) => {
-  const u = req.user as { id: string } | undefined;
-  if (!u) {
+  const u = req.user as { id: string; acr?: string; scope?: string[] } | undefined;
+  if (!u || !isStepUpContext(u)) {
     res.status(401).json({ message: "Unauthorized" });
     return;
   }
@@ -61,6 +76,46 @@ export const challengeVerify: RequestHandler = async (req: any, res) => {
   }
   await resetTotpLimiter(res);
   await setTrustedDevice(res, u.id);
-  const token = jwt.signAccess(u.id, { acr: "aal2", amr: ["pwd", "otp"] });
-  res.json({ token, acr: "aal2" });
+  const username = extractUsername((u as any)?.token);
+  const session = await auth.createSession(u.id, username, {
+    acr: "aal2",
+    amr: ["pwd", "otp"],
+  });
+  const sid = deriveSid(session.refresh);
+  const exp = decodeExp(session.access);
+  scheduleTokenExpiringSoon(sid, exp);
+  res
+    .cookie("refreshToken", session.refresh, cookieOpts)
+    .json({ token: session.access, acr: "aal2", username });
+};
+
+const decodeExp = (token: string) => {
+  try {
+    const d: any = jwt.decode(token);
+    return typeof d?.exp === "number" ? d.exp : 0;
+  } catch {
+    return 0;
+  }
+};
+
+const isStepUpContext = (user: { acr?: string; scope?: string[] }) => {
+  if (user.acr === "step-up" || user.acr === "aal2") return true;
+  const scope = Array.isArray(user.scope) ? user.scope : [];
+  return scope.includes("auth:stepup");
+};
+
+const extractUsername = (token: string | undefined | null): string | null => {
+  if (!token) return null;
+  try {
+    const payload: any = jwt.decode(token);
+    const uname =
+      typeof payload?.username === "string"
+        ? payload.username
+        : typeof payload?.preferred_username === "string"
+        ? payload.preferred_username
+        : null;
+    return uname;
+  } catch {
+    return null;
+  }
 };

--- a/technomoney-auth/src/middlewares/auth.middleware.ts
+++ b/technomoney-auth/src/middlewares/auth.middleware.ts
@@ -3,6 +3,19 @@ import { logger } from "../utils/log/logger";
 
 const jwtSvc = new JwtService();
 
+const normalizeScope = (scope: unknown): string[] => {
+  if (Array.isArray(scope)) {
+    return scope.filter((s): s is string => typeof s === "string");
+  }
+  if (typeof scope === "string") {
+    return scope
+      .split(" ")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return [];
+};
+
 export const authenticate = (req: any, res: any, next: any) => {
   try {
     const auth = String(req.headers.authorization || "");
@@ -11,11 +24,42 @@ export const authenticate = (req: any, res: any, next: any) => {
       res.status(401).json({ message: "Unauthorized" });
       return;
     }
-    const { id, jti, scope, acr, amr } = jwtSvc.verifyAccess(token);
-    req.user = { id, jti, scope, acr, amr };
+    const { id, jti, scope, acr, amr, username, email, exp } =
+      jwtSvc.verifyAccess(token);
+    const scopeList = normalizeScope(scope);
+    req.user = {
+      id,
+      jti,
+      scope: scopeList,
+      acr,
+      amr,
+      token,
+      username: typeof username === "string" ? username : undefined,
+      email: typeof email === "string" ? email : undefined,
+      exp,
+    };
+    req.authContext = {
+      scope: scopeList,
+      acr: typeof acr === "string" ? acr : "aal1",
+    };
     next();
   } catch (e) {
     logger.debug({ err: String(e) }, "auth.middleware.denied");
     res.status(401).json({ message: "Unauthorized" });
   }
+};
+
+export const requireFullSession = (req: any, res: any, next: any) => {
+  const user = req.user as { acr?: string; scope?: string[] } | undefined;
+  if (!user) {
+    res.status(401).json({ message: "Unauthorized" });
+    return;
+  }
+  const acr = user.acr;
+  const scope = Array.isArray(user.scope) ? user.scope : [];
+  if (acr === "step-up" || scope.includes("auth:stepup")) {
+    res.status(401).json({ stepUp: "totp" });
+    return;
+  }
+  next();
 };

--- a/technomoney-auth/src/routes/auth.routes.ts
+++ b/technomoney-auth/src/routes/auth.routes.ts
@@ -12,7 +12,7 @@ import {
   refresh,
   logout,
 } from "../controllers/auth.controller";
-import { authenticate } from "../middlewares/auth.middleware";
+import { authenticate, requireFullSession } from "../middlewares/auth.middleware";
 import { enforcePasswordPolicy } from "../middlewares/passwordPolicy.middleware";
 import { csrfProtection } from "../middlewares/csrf.middleware";
 import { wsTicket } from "../controllers/ws.controller";
@@ -37,7 +37,7 @@ router.post(
 );
 router.post("/refresh", csrfProtection, refresh);
 router.post("/logout", csrfProtection, logout);
-router.post("/ws-ticket", authenticate, wsTicket);
+router.post("/ws-ticket", authenticate, requireFullSession, wsTicket);
 
 const csrfGet: RequestHandler = (req: any, res) => {
   const token = typeof req.csrfToken === "function" ? req.csrfToken() : "";
@@ -51,6 +51,6 @@ const csrfGet: RequestHandler = (req: any, res) => {
 };
 router.get("/csrf", csrfProtection, csrfGet);
 
-router.get("/me", authenticate, me);
+router.get("/me", authenticate, requireFullSession, me);
 
 export default router;

--- a/technomoney-auth/src/services/jwt.service.ts
+++ b/technomoney-auth/src/services/jwt.service.ts
@@ -12,6 +12,9 @@ type AccessData = {
   scope?: unknown;
   acr?: unknown;
   amr?: unknown;
+  username?: unknown;
+  email?: unknown;
+  exp?: number;
 };
 type RefreshData = { id: string; jti: string };
 
@@ -191,7 +194,26 @@ export class JwtService {
         sub: mask(sub),
         jti: maskJti(String(d.jti || "")),
       });
-      return { id: d.id, jti: d.jti, scope: d.scope, acr: d.acr, amr: d.amr };
+      const username =
+        typeof (d as any).username === "string"
+          ? (d as any).username
+          : typeof (d as any).preferred_username === "string"
+          ? (d as any).preferred_username
+          : undefined;
+      const email =
+        typeof (d as any).email === "string"
+          ? (d as any).email
+          : undefined;
+      return {
+        id: d.id,
+        jti: d.jti,
+        scope: d.scope,
+        acr: d.acr,
+        amr: d.amr,
+        username,
+        email,
+        exp: typeof d.exp === "number" ? d.exp : undefined,
+      };
     } catch (e: any) {
       this.log.warn({
         evt: "jwt.verify.access.fail",

--- a/technomoney-auth/src/types/auth.dto.ts
+++ b/technomoney-auth/src/types/auth.dto.ts
@@ -8,3 +8,15 @@ export interface RefreshTokensDto {
   access: string;
   refresh: string;
 }
+
+export interface StepUpTokenDto {
+  token: string;
+  acr: string;
+  scope: string[];
+  username: string | null;
+}
+
+export interface LoginResult {
+  id: string;
+  username: string | null;
+}


### PR DESCRIPTION
## Summary
- restructure the auth service to issue restricted step-up tokens, create sessions only after MFA, and include username metadata in access tokens
- update authentication and TOTP controllers/middlewares plus API guards to reject step-up tokens until a TOTP challenge succeeds and require AAL2 where needed
- adapt the frontend login flow and MFA components/tests to handle temporary tokens for TOTP endpoints and exchange them for full sessions after verification

## Testing
- `npm test` (from `technomoney-auth`)
- `npm test -- --watch=false` *(fails: react-scripts missing due to private registry restrictions)*


------
https://chatgpt.com/codex/tasks/task_b_68cca8c21b60832fb078f5002ee1814d