### PR TITLE
feat: validate dpop ath binding

### DIFF
--- a/technomoney-api/src/middlewares/__tests__/dpop.middleware.spec.ts
+++ b/technomoney-api/src/middlewares/__tests__/dpop.middleware.spec.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  SignJWT,
+  calculateJwkThumbprint,
+  exportJWK,
+  generateKeyPair,
+} from "jose";
+import { requireDPoPIfBound } from "../dpop.middleware";
+
+type Req = {
+  protocol: string;
+  method: string;
+  originalUrl: string;
+  headers: Record<string, string>;
+  get: (name: string) => string;
+  user?: any;
+};
+
+type Res = {
+  statusCode?: number;
+  body?: any;
+  status: (code: number) => Res;
+  json: (body: any) => Res;
+};
+
+test("requireDPoPIfBound allows requests with matching ath", async () => {
+  const token = "token-value";
+  const { req, res, next, flags } = await setup(token, true);
+  await requireDPoPIfBound(req, res, next);
+  assert.equal(res.statusCode, undefined);
+  assert.equal(flags.calledNext, true);
+});
+
+test("requireDPoPIfBound rejects requests with mismatching ath", async () => {
+  const token = "token-value";
+  const { req, res, next, flags } = await setup(token, false);
+  await requireDPoPIfBound(req, res, next);
+  assert.equal(flags.calledNext, false);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, { message: "invalid dpop ath" });
+});
+
+async function setup(token: string, correctAth: boolean) {
+  const { privateKey, publicKey } = await generateKeyPair("ES256");
+  const jwk = await exportJWK(publicKey);
+  const jkt = await calculateJwkThumbprint(jwk);
+  const method = "GET";
+  const host = "api.example.com";
+  const path = "/resource";
+  const htu = `https://${host}${path}`;
+  const ath = hashToken(correctAth ? token : `${token}-wrong`);
+  const proof = await new SignJWT({
+    htm: method,
+    htu,
+    iat: Math.floor(Date.now() / 1000),
+    jti: randomUUID(),
+    ath,
+  })
+    .setProtectedHeader({ alg: "ES256", typ: "dpop+jwt", jwk })
+    .sign(privateKey);
+
+  const req: Req = {
+    protocol: "https",
+    method,
+    originalUrl: `${path}?foo=bar`,
+    headers: { dpop: proof },
+    get: (name: string) => {
+      if (name.toLowerCase() === "host") return host;
+      throw new Error(`unexpected header ${name}`);
+    },
+    user: {
+      token,
+      payload: { cnf: { jkt } },
+    },
+  };
+
+  const res: Res = {
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: any) {
+      this.body = body;
+      return this;
+    },
+  };
+
+  const flags = { calledNext: false };
+  const next = () => {
+    flags.calledNext = true;
+  };
+
+  return { req, res, next, flags };
+}
+
+function hashToken(token: string) {
+  const base64 = createHash("sha256").update(token).digest("base64");
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}

--- a/technomoney-api/src/middlewares/auth.middleware.ts
+++ b/technomoney-api/src/middlewares/auth.middleware.ts
@@ -42,6 +42,7 @@ export const authenticate = async (req: any, res: any, next: any) => {
     req.user = {
       id,
       jti,
+      token,
       scope: scopeList,
       payload,
       acr,

--- a/technomoney-auth/scripts/run-tests.cjs
+++ b/technomoney-auth/scripts/run-tests.cjs
@@ -27,7 +27,17 @@ function run(command, args, options = {}) {
     TS_NODE_TRANSPILE_ONLY: "1",
     TS_NODE_FILES: "1",
   };
-  await run("node", ["--test", "-r", "ts-node/register", "src/controllers/__tests__/auth.controller.spec.ts"], {
-    env,
-  });
+  await run(
+    "node",
+    [
+      "--test",
+      "-r",
+      "ts-node/register",
+      "src/controllers/__tests__/auth.controller.spec.ts",
+      "src/middlewares/__tests__/dpop.middleware.spec.ts",
+    ],
+    {
+      env,
+    }
+  );
 })();

--- a/technomoney-auth/src/middlewares/__tests__/dpop.middleware.spec.ts
+++ b/technomoney-auth/src/middlewares/__tests__/dpop.middleware.spec.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  SignJWT,
+  calculateJwkThumbprint,
+  exportJWK,
+  generateKeyPair,
+} from "jose";
+import { requireDPoPIfBound } from "../dpop.middleware";
+
+type Req = {
+  protocol: string;
+  method: string;
+  originalUrl: string;
+  headers: Record<string, string>;
+  get: (name: string) => string;
+  user?: any;
+};
+
+type Res = {
+  statusCode?: number;
+  body?: any;
+  status: (code: number) => Res;
+  json: (body: any) => Res;
+};
+
+test("authorization server middleware accepts proof with matching ath", async () => {
+  const token = "auth-token";
+  const { req, res, next, flags } = await setup(token, true);
+  await requireDPoPIfBound(req, res, next);
+  assert.equal(res.statusCode, undefined);
+  assert.equal(flags.calledNext, true);
+});
+
+test("authorization server middleware rejects proof with mismatching ath", async () => {
+  const token = "auth-token";
+  const { req, res, next, flags } = await setup(token, false);
+  await requireDPoPIfBound(req, res, next);
+  assert.equal(flags.calledNext, false);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, { message: "invalid dpop ath" });
+});
+
+async function setup(token: string, correctAth: boolean) {
+  const { privateKey, publicKey } = await generateKeyPair("ES256");
+  const jwk = await exportJWK(publicKey);
+  const jkt = await calculateJwkThumbprint(jwk);
+  const method = "POST";
+  const host = "auth.example.com";
+  const path = "/token";
+  const htu = `https://${host}${path}`;
+  const ath = hashToken(correctAth ? token : `${token}-bad`);
+  const proof = await new SignJWT({
+    htm: method,
+    htu,
+    iat: Math.floor(Date.now() / 1000),
+    jti: randomUUID(),
+    ath,
+  })
+    .setProtectedHeader({ alg: "ES256", typ: "dpop+jwt", jwk })
+    .sign(privateKey);
+
+  const req: Req = {
+    protocol: "https",
+    method,
+    originalUrl: `${path}?client_id=123`,
+    headers: { dpop: proof },
+    get: (name: string) => {
+      if (name.toLowerCase() === "host") return host;
+      throw new Error(`unexpected header ${name}`);
+    },
+    user: {
+      token,
+      payload: { cnf: { jkt } },
+    },
+  };
+
+  const res: Res = {
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: any) {
+      this.body = body;
+      return this;
+    },
+  };
+
+  const flags = { calledNext: false };
+  const next = () => {
+    flags.calledNext = true;
+  };
+
+  return { req, res, next, flags };
+}
+
+function hashToken(token: string) {
+  const base64 = createHash("sha256").update(token).digest("base64");
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}

--- a/technomoney-auth/src/middlewares/dpop.middleware.ts
+++ b/technomoney-auth/src/middlewares/dpop.middleware.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import type { JWK } from "jose";
 import { joseImport } from "../utils/joseDynamic";
 
@@ -15,6 +16,7 @@ export async function requireDPoPIfBound(req: any, res: any, next: any) {
   if (!cnf?.jkt) return next();
   const proof = String(req.headers["dpop"] || "");
   if (!proof) return res.status(401).json({ message: "DPoP required" });
+  const token = typeof req.user?.token === "string" ? req.user.token : undefined;
   try {
     const { calculateJwkThumbprint, importJWK, jwtVerify } = await joseImport();
     const { payload, protectedHeader } = await jwtVerify(
@@ -25,6 +27,8 @@ export async function requireDPoPIfBound(req: any, res: any, next: any) {
       },
       { clockTolerance: 5 }
     );
+    if (!token)
+      return res.status(401).json({ message: "invalid dpop ath" });
     const htm = String(payload.htm || "").toUpperCase();
     const htu = String(payload.htu || "");
     const iat = Number(payload.iat || 0);
@@ -36,6 +40,10 @@ export async function requireDPoPIfBound(req: any, res: any, next: any) {
     if (!iat || Math.abs(now() - iat) > 300)
       return res.status(401).json({ message: "invalid dpop iat" });
     if (!jti) return res.status(401).json({ message: "invalid dpop jti" });
+    const expectedAth = createHash("sha256").update(token).digest("base64");
+    const normalizedAth = expectedAth.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+    if (typeof payload.ath !== "string" || payload.ath !== normalizedAth)
+      return res.status(401).json({ message: "invalid dpop ath" });
     const exp = seen.get(jti);
     if (exp && exp > now()) return res.status(401).json({ message: "replay" });
     seen.set(jti, now() + 600);


### PR DESCRIPTION
## Summary
- retain the raw access token on `req.user` in the resource server to support DPoP validation
- require matching DPoP `ath` hashes in both API and authorization server middlewares
- add integration-style tests that cover accepted and rejected DPoP proofs and include them in the auth test runner

## Testing
- `node --test -r ts-node/register src/middlewares/__tests__/dpop.middleware.spec.ts` *(fails: missing ts-node/register because npm install is blocked by 403 from registry)*
- `npm test` *(fails: missing jose dependency because npm install is blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_b_68cd3ed197cc832f93d36916f9bf4a79