### PR TITLE
Add ts-node bridge for sequelize migrations

### DIFF
--- a/technomoney-auth/README.md
+++ b/technomoney-auth/README.md
@@ -9,10 +9,24 @@ Serviço responsável por autenticação, emissão de tokens e suporte a fluxos 
 | `TOTP_ENC_KEY` | Sim | Chave forte (>= 32 caracteres) para criptografar segredos TOTP. |
 | `INTROSPECTION_CLIENTS` | Sim | Lista separada por vírgula no formato `clientId:clientSecret` autorizada a consultar `/oauth2/introspect`. |
 | `INTROSPECTION_MTLS_ALLOWED_CNS` | Não | Lista opcional de valores `CN` aceitos para clientes autenticados via mTLS. |
+| `DB_USERNAME` | Sim | Usuário dedicado do banco de dados. Garanta privilégios mínimos para reduzir impacto em caso de comprometimento. |
+| `DB_PASSWORD` | Sim | Senha forte do banco de dados, armazenada em cofre seguro. |
+| `DB_DATABASE` | Sim | Nome do banco utilizado pelo serviço de autenticação. |
+| `DB_HOST` | Sim | Host do servidor de banco de dados acessível somente pela rede interna confiável. |
+| `DB_PORT` | Sim | Porta do banco (ex.: `5432` para PostgreSQL). |
+| `DB_DRIVER` | Sim | Dialeto suportado pelo Sequelize (ex.: `postgres`). |
 
 > Gere segredos exclusivos por cliente e mantenha-os em um cofre seguro. Tokens
 > de acesso só são considerados ativos se a sessão (`sid`) correspondente estiver
 > marcada como não revogada na tabela `sessions`.
+
+## Migrações do banco de dados
+
+1. Configure as variáveis de ambiente acima (idealmente via `prod.env` ou um gerenciador seguro de segredos).
+2. Certifique-se de que o arquivo `.sequelizerc` aponte para `src/config/config.js`, que expõe as credenciais TypeScript para o `sequelize-cli` com suporte a `ts-node`.
+3. Execute `npx sequelize-cli db:migrate` para aplicar as migrações existentes, incluindo a criação da tabela `sessions`, antes de liberar o login em produção.
+
+> Restrinja o acesso a esse comando a pipelines autenticadas e monitore a execução para evitar execuções indevidas que possam alterar o esquema sem autorização.
 
 ## Boas práticas de segurança
 

--- a/technomoney-auth/prod.env
+++ b/technomoney-auth/prod.env
@@ -12,5 +12,6 @@ DB_USERNAME=
 DB_PASSWORD=
 DB_DATABASE=TechnomoneyAuth
 DB_HOST=
+DB_PORT=5432
 DB_DRIVER=mssql
 NODE_ENV='production'

--- a/technomoney-auth/scripts/run-tests.cjs
+++ b/technomoney-auth/scripts/run-tests.cjs
@@ -44,6 +44,7 @@ function run(command, args, options = {}) {
       "src/controllers/__tests__/auth.controller.spec.ts",
       "src/controllers/__tests__/oidc.introspect.spec.ts",
       "src/middlewares/__tests__/dpop.middleware.spec.ts",
+      "src/config/__tests__/config.bridge.spec.ts",
     ],
     {
       env,

--- a/technomoney-auth/src/config/__tests__/config.bridge.spec.ts
+++ b/technomoney-auth/src/config/__tests__/config.bridge.spec.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import configTs from "../config";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const configJs = require("../config.js");
+
+test("config.js reexports the TypeScript database configuration", () => {
+  assert.deepEqual(
+    configJs,
+    configTs,
+    "config.js should expose the same configuration exported by config.ts",
+  );
+});

--- a/technomoney-auth/src/config/config.js
+++ b/technomoney-auth/src/config/config.js
@@ -1,0 +1,18 @@
+const path = require("path");
+
+try {
+  require.resolve("ts-node/register");
+  require("ts-node").register({
+    transpileOnly: true,
+    compilerOptions: {
+      module: "CommonJS",
+    },
+    project: path.resolve(__dirname, "..", "..", "tsconfig.json"),
+  });
+} catch (error) {
+  // Ignore if ts-node is not installed; assume a compiled version is available.
+}
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const config = require("./config.ts");
+module.exports = config.default || config;


### PR DESCRIPTION
## Summary
- add a JavaScript bridge so sequelize-cli can load the TypeScript database config with ts-node
- document database environment variables, add the missing DB_PORT default and remind how to run migrations
- cover the new bridge with a unit test and ensure it runs with the existing test script

## Testing
- npm test
- npx sequelize-cli db:migrate *(fails: npm registry access returned 403 in the container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d1d446ac98832f86a3b558fd200286