### PR TITLE
fix: type request user in aal2 middleware

### DIFF
--- a/technomoney-auth/src/middlewares/requireAAL2.middleware.ts
+++ b/technomoney-auth/src/middlewares/requireAAL2.middleware.ts
@@ -1,9 +1,18 @@
+import type { Request, Response, NextFunction } from "express";
+import type { TechnomoneyAuthenticatedUser } from "@technomoney/types/express";
+
 import { TotpService } from "../services/totp.service";
+
+type RequestWithUser = Request & { user?: TechnomoneyAuthenticatedUser };
 
 const totp = new TotpService();
 
-export const requireAAL2 = async (req: any, res: any, next: any) => {
-  const u = req.user as { id?: string; acr?: string } | undefined;
+export const requireAAL2 = async (
+  req: RequestWithUser,
+  res: Response,
+  next: NextFunction,
+) => {
+  const u = req.user;
   if (u && u.acr === "aal2") {
     next();
     return;


### PR DESCRIPTION
## Summary
- type the AAL2 middleware request using the shared TechnomoneyAuthenticatedUser
- update middleware signature to leverage the typed request when accessing the authenticated user

## Testing
- npm run build *(fails: missing module type declarations such as cookie-parser, helmet, swagger-ui-express, sequelize, jose, qrcode, csurf, express-rate-limit, redis, rate-limit-redis, uuid, rate-limiter-flexible, zod, base64url, yamljs, pino, argon2, ioredis, ws)*

------
https://chatgpt.com/codex/tasks/task_b_68d1f3b3e7d8832fbe15c0d944e11f3d