### PR TITLE
Preserve AAL2 claims on refresh via trusted device metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ produção.
   `amr` deduplicados e os claims `trusted_device*` sem reemitir o TOTP. O segredo
   utilizado para assinar o cookie deriva de `TRUSTED_DEVICE_SECRET` (mínimo 32
   caracteres) ou, na ausência dele, da chave privada ativa do JWT.
+- O fluxo `POST /api/auth/refresh` agora reaproveita com segurança os metadados
+  do trusted device (quando pertencem ao mesmo usuário) para assinar o novo
+  access token com `acr=aal2` e `amr` deduplicados. Tentativas de reutilizar
+  cookies de outro usuário são descartadas, garantindo que endpoints AAL2 como
+  `/assets` continuem acessíveis após recarregar a página.
 - Correção no controlador de login garante que o Express exponha `Request`
   tipado corretamente ao reconstruir sessões de dispositivos confiáveis, evitando
   crashes do `ts-node` e reforçando a reutilização segura do cookie `tdid` para

--- a/technomoney-auth/README.md
+++ b/technomoney-auth/README.md
@@ -64,8 +64,12 @@ restritivo, cookies seguros e forçamento de HTTPS).
 
 #### Renovação e revogação
 - `POST /api/auth/refresh` valida token de atualização, verifica se o `sid`
-  continua ativo e retorna tokens novos. Tentativas de reuse geram log de auditoria
-  `auth.refresh.reuse_detected` e revogam a sessão.
+  continua ativo e retorna tokens novos. Quando o par `tdid`/`tdmeta` pertence ao
+  mesmo usuário, os metadados do trusted device são reutilizados para assinar o
+  novo access token com `acr=aal2`, `amr` deduplicados e claims
+  `trusted_device*`, garantindo que rotas protegidas por MFA permaneçam acessíveis
+  após um refresh. Tentativas de reuse ou de reaproveitar cookies de outro usuário
+  são ignoradas, e o fluxo mantém `aal1`.
 - `POST /api/auth/logout` e `AuthService.resetPassword` revogam todos os refresh
   tokens ativos do usuário.
 


### PR DESCRIPTION
## Summary
- sanitize session metadata and reuse trusted device claims when issuing refreshed access tokens
- reuse device metadata in the refresh controller only when it belongs to the authenticated user
- extend unit test suites to cover the new refresh flow and document the behaviour in the READMEs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d48e12fe94832f88e06060f78fd458