### PR TITLE
fix: guard frontend http client against missing base urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,5 +116,10 @@ produção.
   parâmetros de CSRF (`VITE_CSRF_*`) antes de executar, além do novo
   `VITE_AI_AGENT_URL`. O front exige HTTPS e `withCredentials=true` para operar
   com o autenticador e o serviço de IA.
+- O cliente HTTP valida se todas as variáveis `VITE_*` de URL estão definidas
+  (`VITE_API_URL`, `VITE_AUTH_API_URL`, `VITE_PAYMENTS_API_URL` e
+  `VITE_AI_AGENT_URL`). Caso alguma falte, a inicialização falha explicitamente,
+  evitando que o navegador tente chamar origens indefinidas e exponha dados
+  sensíveis.
 - Em caso de falhas na API de mercado, a interface apresenta mensagens de erro
   com ação de retry sem expor detalhes sensíveis ao usuário final.

--- a/technomoney-app/prod.env
+++ b/technomoney-app/prod.env
@@ -1,11 +1,11 @@
 # URLs base dos serviços (use sempre HTTPS em produção)
-VITE_API_URL=http://localhost:4002/api
-VITE_AUTH_API_URL=http://localhost:4000/api
-VITE_PAYMENTS_API_URL=http://localhost:3001/api/payments
-VITE_AI_AGENT_URL=http://localhost:4010/api/ia
+VITE_API_URL=https://api.technomoney.local/api
+VITE_AUTH_API_URL=https://auth.technomoney.local/api
+VITE_PAYMENTS_API_URL=https://payments.technomoney.local/api/payments
+VITE_AI_AGENT_URL=https://ia.technomoney.local/api/ia
 
 # Configurações de segurança e CSRF
-VITE_RECAPTCHA_SITEKEY=
+VITE_RECAPTCHA_SITEKEY=insira-a-chave-publica-do-recaptcha
 VITE_CSRF_COOKIE_NAME=csrf
 VITE_CSRF_HEADER_NAME=x-csrf-token
 VITE_CSRF_PATH=/auth/csrf

--- a/technomoney-app/src/services/http.ts
+++ b/technomoney-app/src/services/http.ts
@@ -85,9 +85,18 @@ interface CreateApiOptions {
 }
 
 function createApi(
-  rawBaseURL: string,
+  rawBaseURLInput: string | null | undefined,
   { enableAuthRefresh = true }: CreateApiOptions = {}
 ): AxiosInstance {
+  const rawBaseURL =
+    typeof rawBaseURLInput === "string" ? rawBaseURLInput.trim() : "";
+
+  if (!rawBaseURL) {
+    throw new Error(
+      "[http] Base URL não configurada. Verifique as variáveis VITE_* do frontend."
+    );
+  }
+
   const baseURL = rawBaseURL.replace(/\/+$/, "");
   const instance = axios.create({
     baseURL,


### PR DESCRIPTION
## Summary
- guard the frontend axios factory against missing base URLs so we fail fast when env vars are undefined
- document the mandatory VITE_* endpoints and update the production env template with secure HTTPS placeholders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e45b517dc4832fad30a077259a6542