### PR TITLE
Fix IA HTTP logger severity and add coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ produção.
   auditoria da recomendação. Use `AGENT_BUY_THRESHOLD` > `AGENT_HOLD_THRESHOLD`
   para controlar a sensibilidade do modelo e monitore logs `ia.auth.denied` para
   detectar tokens inválidos ou tentativas de abuso.
+- O logger HTTP agora respeita os níveis corretos (`info` para 2xx/3xx, `warn`
+  para 4xx e `error` apenas quando há falha real), reduzindo ruído operacional e
+  melhorando o monitoramento de incidentes de segurança.
 
 ## `technomoney-app`
 

--- a/technomoney-ia/README.md
+++ b/technomoney-ia/README.md
@@ -8,6 +8,7 @@ Serviço Node.js responsável por orquestrar os agentes de IA/fundamentalistas d
   - Middlewares aplicam Helmet, CORS restrito por ambiente, compressão e rate limit (`express-rate-limit`).
   - O middleware `authenticate` introspecta tokens no autenticador e recusa sessões sem AAL2, tokens step-up ou inativos.
   - Logs sanitizados via Pino evitam vazamento de tokens (`maskToken`).
+  - O logger HTTP usa níveis adequados (`info`/`warn`/`error`) para evitar falsos positivos em observabilidade e facilitar detecção de incidentes reais.
 - **Modelo heurístico**: combina score fundamental (DY, ROE, margem, EV/EBIT), palavras-chave da análise textual e notícias recentes. Thresholds de compra/manutenção são parametrizáveis por ambiente (`AGENT_BUY_THRESHOLD`, `AGENT_HOLD_THRESHOLD`).
 
 ## Rotas

--- a/technomoney-ia/src/utils/logger.spec.ts
+++ b/technomoney-ia/src/utils/logger.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { resolveHttpLogLevel } from "./logger";
+
+describe("resolveHttpLogLevel", () => {
+  const req = {} as IncomingMessage;
+
+  const buildRes = (statusCode: number) =>
+    ({ statusCode } as unknown as ServerResponse<IncomingMessage>);
+
+  it("retorna info para respostas de sucesso", () => {
+    const level = resolveHttpLogLevel(req, buildRes(200));
+    assert.strictEqual(level, "info");
+  });
+
+  it("retorna warn para respostas de cliente", () => {
+    const level = resolveHttpLogLevel(req, buildRes(404));
+    assert.strictEqual(level, "warn");
+  });
+
+  it("retorna error para respostas de servidor", () => {
+    const level = resolveHttpLogLevel(req, buildRes(503));
+    assert.strictEqual(level, "error");
+  });
+
+  it("retorna error quando há exceção", () => {
+    const err = new Error("boom");
+    const level = resolveHttpLogLevel(req, buildRes(200), err);
+    assert.strictEqual(level, "error");
+  });
+});

--- a/technomoney-ia/src/utils/logger.ts
+++ b/technomoney-ia/src/utils/logger.ts
@@ -1,5 +1,7 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
 import pino from "pino";
 import pinoHttp from "pino-http";
+import type { Level } from "pino";
 import { env } from "../config/env";
 
 export const logger = pino({
@@ -13,11 +15,17 @@ export const logger = pino({
       : undefined,
 });
 
+export const resolveHttpLogLevel = (
+  _req: IncomingMessage,
+  res: ServerResponse,
+  err?: Error
+): Level => {
+  if (err || res.statusCode >= 500) return "error";
+  if (res.statusCode >= 400) return "warn";
+  return "info";
+};
+
 export const httpLogger = pinoHttp({
   logger,
-  customLogLevel: (res, err) => {
-    if (err || res.statusCode >= 500) return "error";
-    if (res.statusCode >= 400) return "warn";
-    return "info";
-  },
+  customLogLevel: resolveHttpLogLevel,
 });


### PR DESCRIPTION
## Summary
- fix the IA HTTP logger to respect the intended info/warn/error mapping and export the resolver
- add unit coverage for the log level resolver to guard against regressions
- update service and root READMEs to document the corrected logging behaviour for observability and security

## Testing
- npm test *(fails: requires ts-node/register because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e45df9b424832faaf367557de30035