### PR TITLE
Integrate stock detail flow with fake market data

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ produção.
 - As rotas `/assets` agora expõem dados enriquecidos (`fundamentals`, `marketCap`, textos analíticos) e validam a resposta externa com Zod antes de persistir preços/volumes.
 - Todas as requisições ao domínio de ativos exigem tokens com `acr=aal2`; em caso de ausência o middleware retorna `WWW-Authenticate: error="insufficient_aal"` para forçar MFA.
 - A Fake Market API fornece o novo contrato e deve ser configurada em `MARKET_API_BASE_URL` via HTTPS em produção.
+- O serviço sincroniza automaticamente novos tickers disponibilizados pela fake API, adicionando-os ao banco sem sobrescrever ativos existentes e mantendo o histórico preservado.
 - O middleware de autenticação agora usa somente o fluxo de introspecção via
   `AUTH_INTROSPECTION_URL`, rejeitando sessões inativas imediatamente para
   reduzir superfícies de abuso.
@@ -109,6 +110,7 @@ produção.
 - O dashboard e a carteira deixam de usar mocks e consomem `GET /assets` e
   `GET /assets/:tag` da API principal, reutilizando o cache seguro do React
   Query e respeitando o fluxo de refresh de tokens com AAL2.
+- A página `/stock-detail/:tag` consome a mesma API para preencher gráfico histórico, notícias, análise textual e metadados corporativos, eliminando os mocks anteriores do front-end.
 - Toda requisição passa pelo `fetchApiWithAuth`, que injeta o Bearer atual e
   executa um único refresh em caso de `401`, mantendo o rigor de segurança do
   backend.

--- a/technomoney-api/README.md
+++ b/technomoney-api/README.md
@@ -152,3 +152,4 @@ Retorna o detalhamento completo da ação (indicadores fundamentais, texto anal�
 - A variável `MARKET_API_BASE_URL` deve apontar para uma instância compatível com o novo contrato (`ticker`, métricas fundamentais, textos descritivos e série histórica).
 - Os dados são revalidados a cada requisição. Quaisquer campos faltantes disparam `502` e impedem gravações inconsistentes no banco.
 - O serviço persiste `price`, `variation` (em %) e `volume` na tabela `asset_records`; demais campos vêm somente da API de mercado em tempo real.
+- Se a fake API expor um ticker ainda não cadastrado, o serviço registra automaticamente o ativo sem sobrescrever registros existentes, atendendo ao requisito de apenas adicionar novos dados quando necessário.

--- a/technomoney-api/prod.env
+++ b/technomoney-api/prod.env
@@ -15,6 +15,7 @@ DB_DRIVER=postgres
 
 # Integrações externas
 # Base HTTPS da API de mercado compatível com o contrato enriquecido (ticker, fundamentals, notícias)
+# Ex.: http://technomoney-fake-api:4001 em ambientes de desenvolvimento controlados
 MARKET_API_BASE_URL=
 SWAGGER_FILE=
 

--- a/technomoney-api/src/services/__tests__/asset.service.spec.ts
+++ b/technomoney-api/src/services/__tests__/asset.service.spec.ts
@@ -5,6 +5,8 @@ import { AssetService } from "../asset.service";
 import type { ApiAsset } from "../market-data.service";
 
 class FakeAssetRepository {
+  public created: any[] = [];
+
   constructor(private readonly items: any[]) {}
 
   async findAll() {
@@ -16,7 +18,20 @@ class FakeAssetRepository {
   }
 
   async findOrCreate(tag: string, name: string) {
-    return [{ id: 99, tag, name }, true];
+    const existing =
+      this.items.find((item) => item.tag === tag) ||
+      this.items.find((item) => item.name === name);
+    if (existing) {
+      return [existing, false];
+    }
+    const entity = {
+      id: this.items.length + this.created.length + 1,
+      tag,
+      name,
+    };
+    this.created.push(entity);
+    this.items.push(entity);
+    return [entity, true];
   }
 }
 
@@ -25,7 +40,7 @@ class FakeAssetRecordRepository {
   public today: any[] = [];
   private latest: any = null;
 
-  async findToday() {
+  async findToday(_ids?: number[], _start?: Date, _end?: Date) {
     return this.today;
   }
 
@@ -69,37 +84,50 @@ class FakeMarketDataService {
   }
 }
 
+const baseApiAsset: ApiAsset = {
+  ticker: "PETR4",
+  nome: "Petrobras PN",
+  setor: "Energia",
+  preco: 42.5,
+  variacao: 1.7,
+  volume: 12500000,
+  dy: 15.1,
+  roe: 22.4,
+  pl: 3.5,
+  margem: 35.7,
+  ev_ebit: 2.8,
+  liquidez: 12500000,
+  score: 84,
+  marketCap: 320000000000,
+  dividendYield: 0.151,
+  recomendacao: "Comprar",
+  analise: "Fluxo de caixa forte e política de dividendos agressiva.",
+  bio: "Companhia integrada de energia.",
+  noticias: [
+    "Petrobras expande CAPEX em projetos do pré-sal.",
+    "Conselho aprova distribuição extraordinária de dividendos.",
+  ],
+  grafico: [40, 41, 42, 43],
+  sede: "Rio de Janeiro, RJ",
+  industria: "Energia",
+  fundacao: 1953,
+  empregados: 45000,
+};
+
+const makeApiAsset = (overrides: Partial<ApiAsset> = {}): ApiAsset => ({
+  ...baseApiAsset,
+  ...overrides,
+  noticias: overrides.noticias
+    ? [...overrides.noticias]
+    : [...baseApiAsset.noticias],
+  grafico: overrides.grafico
+    ? [...overrides.grafico]
+    : [...baseApiAsset.grafico],
+});
+
 test("AssetService enriches market data with fundamentals", async () => {
   const asset = { id: 1, tag: "PETR4", name: "Petrobras PN" };
-  const apiAsset: ApiAsset = {
-    ticker: "PETR4",
-    nome: "Petrobras PN",
-    setor: "Energia",
-    preco: 42.5,
-    variacao: 1.7,
-    volume: 12500000,
-    dy: 15.1,
-    roe: 22.4,
-    pl: 3.5,
-    margem: 35.7,
-    ev_ebit: 2.8,
-    liquidez: 12500000,
-    score: 84,
-    marketCap: 320000000000,
-    dividendYield: 0.151,
-    recomendacao: "Comprar",
-    analise: "Fluxo de caixa forte e política de dividendos agressiva.",
-    bio: "Companhia integrada de energia.",
-    noticias: [
-      "Petrobras expande CAPEX em projetos do pré-sal.",
-      "Conselho aprova distribuição extraordinária de dividendos.",
-    ],
-    grafico: [40, 41, 42, 43],
-    sede: "Rio de Janeiro, RJ",
-    industria: "Energia",
-    fundacao: 1953,
-    empregados: 45000,
-  };
+  const apiAsset = makeApiAsset();
 
   const repo = new FakeAssetRepository([asset]);
   const records = new FakeAssetRecordRepository();
@@ -121,4 +149,20 @@ test("AssetService enriches market data with fundamentals", async () => {
   assert.equal(detail?.noticias.length, 2);
   assert.equal(detail?.grafico.at(-1), 43);
   assert.equal(detail?.fundamentals.ev_ebit, 2.8);
+});
+
+test("AssetService cria assets ausentes usando a fake API", async () => {
+  const repo = new FakeAssetRepository([]);
+  const records = new FakeAssetRecordRepository();
+  const market = new FakeMarketDataService(makeApiAsset());
+  const service = new AssetService(repo as any, records as any, market as any);
+
+  const all = await service.getAllToday();
+  assert.equal(all.length, 1);
+  assert.equal(repo.created.length, 1);
+  assert.equal(repo.created[0].tag, "PETR4");
+  assert.equal(records.added.length, 1);
+  const detail = await service.getByTagToday("PETR4");
+  assert.ok(detail);
+  assert.equal(detail?.nome, "Petrobras PN");
 });

--- a/technomoney-api/src/services/asset.service.ts
+++ b/technomoney-api/src/services/asset.service.ts
@@ -22,6 +22,23 @@ interface AssetEntity {
   name: string;
 }
 
+function toEntity(model: any): AssetEntity {
+  if (!model) return model;
+  if (typeof model.get === "function") {
+    const plain = model.get({ plain: true }) as AssetEntity;
+    return {
+      id: Number(plain.id),
+      tag: String(plain.tag),
+      name: String(plain.name),
+    };
+  }
+  return {
+    id: Number((model as AssetEntity).id),
+    tag: String((model as AssetEntity).tag),
+    name: String((model as AssetEntity).name),
+  };
+}
+
 interface TodayRecord {
   asset_id: number;
   price: number;
@@ -89,23 +106,56 @@ export class AssetService {
     private readonly marketData: MarketDataService
   ) {}
 
+  private async ensureAssetsFromApi(
+    current: AssetEntity[],
+    apiAssets: ApiAsset[]
+  ): Promise<AssetEntity[]> {
+    if (!apiAssets.length) return current;
+
+    const byTag = new Map<string, AssetEntity>();
+    const byName = new Map<string, AssetEntity>();
+    current.forEach((asset) => {
+      byTag.set(toUpper(asset.tag), asset);
+      byName.set(toUpper(asset.name), asset);
+    });
+
+    const result = [...current];
+
+    for (const api of apiAssets) {
+      const normalizedTag = toUpper(api.ticker);
+      const normalizedName = toUpper(api.nome);
+      if (byTag.has(normalizedTag) || byName.has(normalizedName)) continue;
+
+      const [model] = await this.assetRepo.findOrCreate(
+        normalizedTag,
+        api.nome
+      );
+      const entity = toEntity(model);
+      byTag.set(toUpper(entity.tag), entity);
+      byName.set(toUpper(entity.name), entity);
+      result.push(entity);
+    }
+
+    return result;
+  }
+
   create(tag: string, name: string) {
     return this.assetRepo.findOrCreate(tag, name);
   }
 
   async getAllToday(): Promise<AssetSummaryDto[]> {
-    const assets = (await this.assetRepo.findAll()) as unknown as AssetEntity[];
-    if (!assets.length) return [];
+    const assetModels = (await this.assetRepo.findAll()) as unknown[];
+    let assets = assetModels.map(toEntity);
+    const apiAssets = await this.marketData.fetchAll();
+    assets = await this.ensureAssetsFromApi(assets, apiAssets);
+    if (!assets.length || !apiAssets.length) return [];
 
     const { start, end } = getTodayRange();
-    const [todayRecs, apiAssets] = await Promise.all([
-      this.recordRepo.findToday(
-        assets.map((a: AssetEntity) => a.id),
-        start,
-        end
-      ),
-      this.marketData.fetchAll(),
-    ]);
+    const todayRecs = await this.recordRepo.findToday(
+      assets.map((a: AssetEntity) => a.id),
+      start,
+      end
+    );
 
     const recMap = new Map<number, AssetRecordCache>();
     (todayRecs as unknown as TodayRecord[]).forEach((r: TodayRecord) =>
@@ -172,14 +222,22 @@ export class AssetService {
   }
 
   async getByTagToday(tag: string): Promise<AssetDetailDto | null> {
-    const asset = (await this.assetRepo.findByTag(
-      tag
+    const normalizedTag = toUpper(tag);
+    let asset = (await this.assetRepo.findByTag(
+      normalizedTag
     )) as unknown as AssetEntity | null;
-    if (!asset) return null;
 
-    const api = await this.marketData.fetchByName(asset.tag);
+    const api = await this.marketData.fetchByName(normalizedTag);
     if (!api)
       throw new AppError(502, "No data from market API for requested asset");
+
+    if (!asset) {
+      const [model] = await this.assetRepo.findOrCreate(
+        toUpper(api.ticker),
+        api.nome
+      );
+      asset = toEntity(model);
+    }
 
     const price = sanitizeNumber(api.preco, NaN);
     const volume = sanitizeNumber(api.volume ?? api.liquidez, NaN);

--- a/technomoney-app/README.md
+++ b/technomoney-app/README.md
@@ -4,6 +4,7 @@ Front-end desenvolvido em React + Vite que consome os serviços da plataforma Te
 
 ## Fluxo de dados
 - **Dashboard**: consome `GET /assets` do `technomoney-api` para exibir ranking, heatmap e métricas agregadas. Os dados são cacheados com React Query por 30 segundos para reduzir carga.
+- **Detalhamento de ações**: a rota protegida `/stock-detail/:tag` busca `GET /assets/:tag` e renderiza gráfico histórico, análise textual, notícias e metadados corporativos diretamente da fake API de mercado. Não há mais mocks em componentes de detalhe; todo o conteúdo deriva dos dados reais retornados pelo back-end.
 - **Carteira**: utiliza `GET /assets` para montar a lista de tickers e `GET /assets/:tag` para detalhes do ativo selecionado. A tela traduz valores numéricos (preço, DY, fundamentos) e reaproveita o mesmo cache do dashboard.
 - **Agente de IA**: o cartão "Tendência" da carteira envia os detalhes completos do ativo para o serviço `technomoney-ia` via `POST /api/ia/v1/analysis`, recebendo uma avaliação heurística segura (tendência + análise reescrita). O request é autenticado com o mesmo token AAL2 do usuário.
 - **Autenticação**: todo request passa pelo `fetchApiWithAuth`, que injeta o token Bearer atual e executa `refresh` em caso de `401`. Tokens inválidos forçam redirecionamento para o login.
@@ -53,7 +54,7 @@ Front-end desenvolvido em React + Vite que consome os serviços da plataforma Te
 
 ## Integração com o back-end
 - O front depende da `technomoney-api` já protegida por introspecção OAuth2 (AAL2). Configure CORS na API para incluir o domínio do front.
-- A `technomoney-fake-api` pode ser usada em desenvolvimento apontando `MARKET_API_BASE_URL` do `technomoney-api` para `http://localhost:4001`. Ela fornece os dados esperados pelo dashboard/carteira.
+- A `technomoney-fake-api` pode ser usada em desenvolvimento apontando `MARKET_API_BASE_URL` do `technomoney-api` para `http://localhost:4001`. Ela fornece os dados esperados pelo dashboard, pela carteira **e** pela tela de detalhes (incluindo série histórica, notícias e recomendações).
 - Rotas críticas (login, MFA, refresh) usam `withCredentials=true`, portanto configure `Access-Control-Allow-Credentials` no back-end e não utilize curingas (`*`) para `origin`.
 
 ## Testes

--- a/technomoney-app/src/App.tsx
+++ b/technomoney-app/src/App.tsx
@@ -14,7 +14,6 @@ import StockDetail from "./components/Dashboard/StocksDetail/StocksDetail";
 
 import { AuthProvider } from "./context/AuthContext";
 import PrivateRoute from "./private/PrivateRoute";
-import PortfolioPage from "./components/Portfolio/PortfolioPage";
 
 import "./components/Portfolio/styles/tokens.css";
 import "./components/Portfolio/styles/globals.css";
@@ -57,10 +56,10 @@ function App() {
 
               {/* Nova rota para a página de detalhes de ação */}
               <Route
-                path="/stock-detail"
+                path="/stock-detail/:tag"
                 element={
                   <PrivateRoute>
-                    <StockDetail/>
+                    <StockDetail />
                   </PrivateRoute>
                 }
               />

--- a/technomoney-app/src/components/Dashboard/StocksDetail/StockChart.tsx
+++ b/technomoney-app/src/components/Dashboard/StocksDetail/StockChart.tsx
@@ -1,37 +1,84 @@
-import React from "react";
-import { Stock } from "../StocksHome/data";
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import React, { useMemo } from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import type { AssetDetail } from "../../../types/assets";
+
+const priceFormatter = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
 type Props = {
-  stock: Stock;
+  stock: AssetDetail;
 };
 
 const StockChart = ({ stock }: Props) => {
-  const generatePrice = (basePrice: number, month: number) => {
-    const monthlyVariation = (Math.random() - 0.5) * 0.10; 
-    return basePrice * (1 + monthlyVariation); 
-  };
+  const data = useMemo(() => {
+    const history = Array.isArray(stock.grafico) ? stock.grafico : [];
+    if (!history.length) return [];
+    const recent = history.slice(-30);
+    const start = Date.now() - (recent.length - 1) * DAY_IN_MS;
+    return recent.map((price, index) => {
+      const date = new Date(start + index * DAY_IN_MS);
+      const name = date.toLocaleDateString("pt-BR", {
+        day: "2-digit",
+        month: "2-digit",
+      });
+      return { name, price };
+    });
+  }, [stock.grafico]);
 
-  const data = [
-    { name: "Jan", price: generatePrice(stock.preco, 1) },
-    { name: "Feb", price: generatePrice(stock.preco, 2) },
-    { name: "Mar", price: generatePrice(stock.preco, 3) },
-    { name: "Apr", price: generatePrice(stock.preco, 4) },
-    { name: "May", price: generatePrice(stock.preco, 5) },
-    { name: "Jun", price: generatePrice(stock.preco, 6) },
-    { name: "Jul", price: generatePrice(stock.preco, 7) },
-  ];
+  if (!data.length) {
+    return (
+      <div className="stock-panel stock-chart">
+        <h2>Histórico de Preço</h2>
+        <p className="chart-empty">Sem histórico disponível para este ativo.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="stock-chart">
       <h2>Histórico de Preço</h2>
-      <ResponsiveContainer width="100%" height={300}>
+      <ResponsiveContainer width="100%" height={320}>
         <LineChart data={data}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#444" />
-          <XAxis dataKey="name" stroke="#888" />
-          <YAxis stroke="#888" />
-          <Tooltip contentStyle={{ backgroundColor: '#333', borderRadius: '8px', padding: '8px', color: '#fff' }} />
-          <Line type="monotone" dataKey="price" stroke="#22c55e" />
+          <CartesianGrid strokeDasharray="3 3" stroke="#1f2937" />
+          <XAxis dataKey="name" stroke="#94a3b8" tickLine={false} />
+          <YAxis
+            stroke="#94a3b8"
+            tickFormatter={(value) => priceFormatter.format(value)}
+            tickLine={false}
+            width={100}
+          />
+          <Tooltip
+            formatter={(value: number) => priceFormatter.format(value)}
+            contentStyle={{
+              backgroundColor: "#111827",
+              borderRadius: 12,
+              border: "1px solid rgba(255,255,255,0.06)",
+              color: "#f9fafb",
+              fontSize: 12,
+            }}
+          />
+          <Line
+            type="monotone"
+            dataKey="price"
+            stroke="#22c55e"
+            strokeWidth={2}
+            dot={false}
+            activeDot={{ r: 6 }}
+          />
         </LineChart>
       </ResponsiveContainer>
     </div>

--- a/technomoney-app/src/components/Dashboard/StocksDetail/StockInfo.tsx
+++ b/technomoney-app/src/components/Dashboard/StocksDetail/StockInfo.tsx
@@ -1,20 +1,67 @@
 import React from "react";
-import { Stock } from "../StocksHome/data";
 import MetricPill from "../StocksHome/MetricPill";
-import "./StocksDetail.css";
+import type { AssetDetail } from "../../../types/assets";
+
+const currencyFormatter = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+});
+
+const decimalFormatter = new Intl.NumberFormat("pt-BR", {
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+const percentFormatter = new Intl.NumberFormat("pt-BR", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const formatPercent = (value: number, precision: "default" | "fine" = "default") => {
+  const formatter = precision === "fine" ? percentFormatter : decimalFormatter;
+  return `${formatter.format(value)}%`;
+};
+
+const formatMillions = (value: number) => {
+  if (!Number.isFinite(value)) return "N/D";
+  return `${decimalFormatter.format(value / 1_000_000)} mi`;
+};
+
+const formatBillions = (value: number) => {
+  if (!Number.isFinite(value)) return "N/D";
+  const billions = value / 1_000_000_000;
+  if (Math.abs(billions) >= 0.1) {
+    return `${decimalFormatter.format(billions)} bi`;
+  }
+  return currencyFormatter.format(value);
+};
 
 type Props = {
-  stock: Stock;
+  stock: AssetDetail;
 };
 
 const StockInfo = ({ stock }: Props) => {
+  const { fundamentals } = stock;
+  const metrics = [
+    { label: "Preço", value: currencyFormatter.format(stock.preco) },
+    {
+      label: "DY",
+      value: formatPercent(stock.dividendYield * 100, "fine"),
+    },
+    { label: "ROE", value: formatPercent(fundamentals.roe) },
+    { label: "P/L", value: fundamentals.pl.toFixed(1) },
+    { label: "Margem", value: formatPercent(fundamentals.margem) },
+    { label: "EV/EBIT", value: fundamentals.ev_ebit.toFixed(1) },
+    { label: "Liquidez", value: formatMillions(fundamentals.liquidez) },
+    { label: "Score", value: fundamentals.score.toFixed(0) },
+    { label: "Market Cap", value: formatBillions(stock.marketCap) },
+  ];
+
   return (
     <div className="stock-info">
-      <MetricPill label="Preço" value={`R$ ${stock.preco.toFixed(2)}`} />
-      <MetricPill label="DY" value={`${stock.dy.toFixed(1)}%`} />
-      <MetricPill label="ROE" value={`${stock.roe.toFixed(1)}%`} />
-      <MetricPill label="P/L" value={`${stock.pl.toFixed(1)}`} />
-      <MetricPill label="Liquidez" value={`${(stock.liquidez / 1000000).toFixed(1)}M`} />
+      {metrics.map((metric) => (
+        <MetricPill key={metric.label} label={metric.label} value={metric.value} />
+      ))}
     </div>
   );
 };

--- a/technomoney-app/src/components/Dashboard/StocksDetail/StocksDetail.css
+++ b/technomoney-app/src/components/Dashboard/StocksDetail/StocksDetail.css
@@ -26,7 +26,6 @@
   margin-bottom: 20px;
   position: relative;
   padding: 35px;
-  background-color: linear-gradient(90deg, var(--accent), #38bdf8);
   background: rgb(14, 25, 33);
   border-radius: 16px;
   box-shadow: var(--shadow);
@@ -35,7 +34,7 @@
 .StocksDetailheader h1 {
   font-size: 2.8rem;
   color: transparent;
-  font-family: 'Arial', sans-serif;
+  font-family: "Arial", sans-serif;
   text-transform: uppercase;
   background: linear-gradient(90deg, var(--accent), #38bdf8);
   background-clip: text;
@@ -63,15 +62,18 @@
   border-radius: 16px;
   box-shadow: var(--shadow);
   padding: 25px;
-} 
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
 
 .stock-info {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 15px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
   justify-items: center;
   background-color: rgb(14, 25, 33);
-  padding: 5px;
+  padding: 12px;
   border-radius: 16px;
 }
 
@@ -86,33 +88,27 @@
   opacity: 0.9;
   border: 1px solid #08a295;
   border-radius: 16px;
-  padding: 1zpx;
+  padding: 12px;
   background: linear-gradient(180deg, rgba(12, 179, 168, 0.15), transparent);
   font-weight: 600;
   text-align: center;
   transition: all 0.3s ease-in-out;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  height: 80px;
-  max-width: 200px;
+  height: 100px;
+  max-width: 220px;
   width: 100%;
 }
 
 .stock-info .metric-pill .value {
-  font-size: 1.5em;
+  font-size: 1.4em;
   font-weight: bold;
   color: #cde6e1;
 }
 
 .stock-info .metric-pill .label {
-  font-size: 1.1em;
+  font-size: 1em;
   color: #f0f0f0;
   opacity: 0.85;
-}
-
-.stock-info .metric-pill .metric-description {
-  font-size: 0.95em;
-  color: #f0f0f0;
-  opacity: 0.8;
 }
 
 .stock-info .metric-pill:active {
@@ -121,19 +117,128 @@
 }
 
 .stock-chart {
-  margin-top: 40px;
   background-color: var(--card);
-  padding: 1px;
+  padding: 24px;
   border-radius: 16px;
   box-shadow: var(--shadow);
   transition: all 0.3s ease-in-out;
-  justify-items: center;
+}
+
+.stock-chart h2 {
+  margin-bottom: 12px;
+}
+
+.chart-empty {
+  color: var(--muted);
+  margin: 0;
+}
+
+.stock-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 24px;
+}
+
+.stock-panel {
+  background-color: var(--card);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.stock-briefing p {
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.stock-meta {
+  display: grid;
+  gap: 8px;
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+.stock-meta strong {
+  color: #cde6e1;
+}
+
+.stock-news ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.stock-news li {
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(34, 197, 94, 0.08);
+  color: #f8fafc;
+  line-height: 1.4;
+}
+
+.stock-news li::before {
+  content: "•";
+  color: var(--accent);
+  margin-right: 8px;
+}
+
+.stock-recommendation {
+  display: inline-flex;
   align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-top: 12px;
+}
+
+.stock-recommendation.recommend-buy {
+  background: rgba(34, 197, 94, 0.16);
+  color: #4ade80;
+  border: 1px solid rgba(74, 222, 128, 0.3);
+}
+
+.stock-recommendation.recommend-hold {
+  background: rgba(59, 130, 246, 0.16);
+  color: #60a5fa;
+  border: 1px solid rgba(96, 165, 250, 0.3);
+}
+
+.retry-button {
+  margin-top: 16px;
+  padding: 10px 20px;
+  border-radius: 12px;
+  background: var(--accent);
+  color: #04110b;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.retry-button:hover {
+  transform: translateY(-1px);
+}
+
+.loading-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  min-height: 220px;
+  text-align: center;
 }
 
 @media (max-width: 768px) {
   .stock-info {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   }
 
   .stock-info .metric-pill {
@@ -148,16 +253,8 @@
     font-size: 1.1rem;
   }
 
-  .stock-info .metric-pill .value {
-    font-size: 1.3em;
-  }
-
-  .stock-info .metric-pill .label {
-    font-size: 1em;
-  }
-
-  .stock-info .metric-pill .metric-description {
-    font-size: 0.9em;
+  .stock-grid {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/technomoney-app/src/components/Dashboard/StocksDetail/StocksDetail.tsx
+++ b/technomoney-app/src/components/Dashboard/StocksDetail/StocksDetail.tsx
@@ -1,30 +1,133 @@
-import { useLocation } from "react-router-dom";
-import { Stock } from "../StocksHome/data";
+import React from "react";
+import { useLocation, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import StockInfo from "./StockInfo";
 import StockChart from "./StockChart";
+import Spinner from "../../Spinner/Spinner";
+import { fetchAssetDetail } from "../../../services/assets";
+import type { AssetDetail, AssetSummary } from "../../../types/assets";
 import "./StocksDetail.css";
+
+type LocationState = {
+  stock?: AssetSummary;
+};
 
 const StockDetail = () => {
   const location = useLocation();
-  const { stock }: { stock: Stock } = location.state || {};
+  const params = useParams<{ tag?: string }>();
+  const summary = (location.state as LocationState | null)?.stock ?? null;
+  const normalizedTag = (params.tag ?? summary?.tag ?? "").toUpperCase();
 
-  if (!stock) {
-    return <div className="error">Ação não encontrada</div>;
+  const { data, isLoading, isError, refetch } = useQuery<AssetDetail>({
+    queryKey: ["assets", "detail", normalizedTag],
+    queryFn: () => fetchAssetDetail(normalizedTag),
+    enabled: !!normalizedTag,
+    staleTime: 30_000,
+    gcTime: 5 * 60_000,
+  });
+
+  const headerAsset: AssetSummary | null = data ?? summary;
+
+  if (!normalizedTag) {
+    return (
+      <div className="stock-detail-page">
+        <div className="error">Ação não encontrada</div>
+      </div>
+    );
   }
 
   return (
     <div className="stock-detail-page">
-      <div className="StocksDetailheader">
-        <h1>{stock.nome} ({stock.ticker})</h1>
-        <p>{stock.setor}</p>
-        <p className={stock.variacao >= 0 ? "positive" : "negative"}>
-          {stock.variacao >= 0 ? "+" : ""}{stock.variacao.toFixed(2)}%
-        </p>
-      </div>
-      
+      {headerAsset ? (
+        <div className="StocksDetailheader">
+          <h1>
+            {headerAsset.nome} ({headerAsset.tag})
+          </h1>
+          <p>{headerAsset.setor}</p>
+          <p className={headerAsset.variacao >= 0 ? "positive" : "negative"}>
+            {headerAsset.variacao >= 0 ? "+" : ""}
+            {headerAsset.variacao.toFixed(2)}%
+          </p>
+          {data?.recomendacao ? (
+            <span
+              className={`stock-recommendation ${
+                data.recomendacao === "Comprar" ? "recommend-buy" : "recommend-hold"
+              }`}
+            >
+              {data.recomendacao}
+            </span>
+          ) : null}
+        </div>
+      ) : (
+        <div className="StocksDetailheader">
+          <h1>Carregando ativo…</h1>
+        </div>
+      )}
+
       <div className="stock-content">
-        <StockInfo stock={stock} />
-        <StockChart stock={stock} />
+        {isLoading ? (
+          <div className="loading-screen">
+            <Spinner />
+          </div>
+        ) : isError ? (
+          <div className="loading-screen" role="alert">
+            <div>Falha ao carregar detalhes da ação.</div>
+            <button
+              type="button"
+              className="retry-button"
+              onClick={() => refetch()}
+            >
+              Tentar novamente
+            </button>
+          </div>
+        ) : data ? (
+          <>
+            <StockInfo stock={data} />
+            <div className="stock-grid">
+              <div className="stock-panel">
+                <StockChart stock={data} />
+              </div>
+              <div className="stock-panel stock-briefing">
+                <h2>Resumo fundamentalista</h2>
+                <p>{data.analise}</p>
+                <div className="stock-meta">
+                  <span>
+                    <strong>Bio:</strong> {data.bio}
+                  </span>
+                  <span>
+                    <strong>Indústria:</strong> {data.industria}
+                  </span>
+                  <span>
+                    <strong>Sede:</strong> {data.sede}
+                  </span>
+                  <span>
+                    <strong>Fundação:</strong> {data.fundacao}
+                  </span>
+                  <span>
+                    <strong>Empregados:</strong>{" "}
+                    {data.empregados.toLocaleString("pt-BR")}
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div className="stock-panel stock-news">
+              <h2>Notícias recentes</h2>
+              {data.noticias.length ? (
+                <ul>
+                  {data.noticias.map((news, index) => (
+                    <li key={`${index}-${news.slice(0, 24)}`}>{news}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p>Nenhuma notícia disponível para este ativo.</p>
+              )}
+            </div>
+          </>
+        ) : (
+          <div className="loading-screen" role="status">
+            Dados indisponíveis no momento.
+          </div>
+        )}
       </div>
     </div>
   );

--- a/technomoney-app/src/components/Dashboard/StocksDetail/StocksDetailHome.tsx
+++ b/technomoney-app/src/components/Dashboard/StocksDetail/StocksDetailHome.tsx
@@ -1,40 +1,75 @@
-import React, { useState, useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import StockCard from "../StocksHome/StockCard";
-import { Stock } from "../StocksHome/data";
-import { stocks } from "../StocksHome/data";
-import "./StocksHome.css";
+import Spinner from "../../Spinner/Spinner";
+import { fetchAssetSummaries } from "../../../services/assets";
+import type { AssetSummary } from "../../../types/assets";
+import "../StocksHome/StocksHome.css";
+
+const MAX_FIELD = 100;
 
 const StocksDetailHome = () => {
   const navigate = useNavigate();
   const [query, setQuery] = useState("");
+  const { data, isLoading, isError, refetch } = useQuery<AssetSummary[]>({
+    queryKey: ["assets", "detail-home"],
+    queryFn: fetchAssetSummaries,
+    staleTime: 30_000,
+    gcTime: 5 * 60_000,
+  });
 
   const filteredStocks = useMemo(() => {
-    return stocks.filter((stock) =>
-      stock.nome.toLowerCase().includes(query.toLowerCase())
+    const base = data ?? [];
+    if (!query.trim()) return base;
+    const term = query.toLowerCase();
+    return base.filter(
+      (stock) =>
+        stock.nome.toLowerCase().includes(term) ||
+        stock.tag.toLowerCase().includes(term) ||
+        stock.setor.toLowerCase().includes(term)
     );
-  }, [query]);
+  }, [data, query]);
 
-  const handleStockClick = (stock: Stock) => {
-    navigate("/stock-detail", { state: { stock } });
+  const handleStockClick = (stock: AssetSummary) => {
+    navigate(`/stock-detail/${encodeURIComponent(stock.tag)}`, {
+      state: { stock },
+    });
   };
+
+  if (isLoading) {
+    return (
+      <div className="loading-screen">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="loading-screen" role="alert">
+        <div>Não foi possível carregar as ações.</div>
+        <button type="button" className="retry-button" onClick={() => refetch()}>
+          Tentar novamente
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="stocks-home">
       <input
         type="text"
         value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        placeholder="Buscar por ação"
+        onChange={(e) => setQuery(e.target.value.slice(0, MAX_FIELD))}
+        placeholder="Buscar por ticker, nome ou setor"
         className="search-input"
       />
       <div className="stock-list">
-        {filteredStocks.map((stock: Stock) => (
-          <StockCard 
-            key={stock.ticker} 
-            item={stock} 
-            onAdd={() => handleStockClick(stock)} 
-          />
+        {filteredStocks.map((stock) => (
+          <div key={stock.tag} onClick={() => handleStockClick(stock)}>
+            <StockCard item={stock} onAdd={() => handleStockClick(stock)} />
+          </div>
         ))}
       </div>
     </div>

--- a/technomoney-app/src/components/Dashboard/StocksHome/StocksHome.tsx
+++ b/technomoney-app/src/components/Dashboard/StocksHome/StocksHome.tsx
@@ -13,7 +13,7 @@ const MAX_FIELD = 100;
 type Props = { items: AssetSummary[]; onOpenCarteira?: () => void };
 
 const WALLET_ROUTE = "/portfolio";
-const STOCK_DETAIL_ROUTE = "/stock-detail"; 
+const STOCK_DETAIL_ROUTE = "/stock-detail";
 
 export default function StocksHome({ items, onOpenCarteira }: Props) {
   const navigate = useNavigate();
@@ -72,7 +72,9 @@ export default function StocksHome({ items, onOpenCarteira }: Props) {
   };
 
   const handleStockClick = (stock: AssetSummary) => {
-    navigate(STOCK_DETAIL_ROUTE, { state: { stock } });
+    navigate(`${STOCK_DETAIL_ROUTE}/${encodeURIComponent(stock.tag)}`, {
+      state: { stock },
+    });
   };
 
   return (

--- a/technomoney-app/src/services/assets.ts
+++ b/technomoney-app/src/services/assets.ts
@@ -9,8 +9,9 @@ export async function fetchAssetSummaries(): Promise<AssetSummary[]> {
 }
 
 export async function fetchAssetDetail(tag: string): Promise<AssetDetail> {
+  const normalizedTag = String(tag ?? "").trim().toUpperCase();
   const response = await fetchApiWithAuth<AssetDetail>(
-    `/assets/${encodeURIComponent(tag)}`,
+    `/assets/${encodeURIComponent(normalizedTag)}`,
     {
       method: "GET",
     }

--- a/technomoney-auth/src/services/__tests__/token.service.spec.ts
+++ b/technomoney-auth/src/services/__tests__/token.service.spec.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const loggerPath = require.resolve("../../utils/log/logger");
+require.cache[loggerPath] = {
+  id: loggerPath,
+  filename: loggerPath,
+  loaded: true,
+  exports: {
+    logger: {
+      debug() {},
+      info() {},
+      warn() {},
+      error() {},
+    },
+    getLogger: () => ({
+      debug() {},
+      info() {},
+      warn() {},
+      error() {},
+    }),
+  },
+} as any;
+
+const repoPath = require.resolve("../../repositories/refresh-token.repository");
+
+class StubRefreshTokenRepository {
+  public saved: { token: string; userId: string }[] = [];
+  public revoked: string[] = [];
+  public revokedAllForUser: string[] = [];
+  public validated: string[] = [];
+  public issued: string[] = [];
+
+  async save(tokenHash: string, userId: string) {
+    this.saved.push({ token: tokenHash, userId });
+  }
+
+  async revoke(tokenHash: string) {
+    this.revoked.push(tokenHash);
+  }
+
+  async revokeAllForUser(userId: string) {
+    this.revokedAllForUser.push(userId);
+  }
+
+  async isValid(tokenHash: string) {
+    this.validated.push(tokenHash);
+    return this.saved.find((entry) => entry.token === tokenHash) ? {} : null;
+  }
+
+  async wasIssued(tokenHash: string) {
+    this.issued.push(tokenHash);
+    return this.saved.find((entry) => entry.token === tokenHash) ? {} : null;
+  }
+}
+
+let repoInstance: StubRefreshTokenRepository;
+
+require.cache[repoPath] = {
+  id: repoPath,
+  filename: repoPath,
+  loaded: true,
+  exports: {
+    RefreshTokenRepository: class {
+      constructor() {
+        repoInstance = new StubRefreshTokenRepository();
+        return repoInstance as any;
+      }
+    },
+  },
+} as any;
+
+const { TokenService } = require("../token.service");
+
+test.after(() => {
+  delete require.cache[loggerPath];
+  delete require.cache[repoPath];
+  delete require.cache[require.resolve("../token.service")];
+});
+
+test("TokenService persiste apenas hashes dos refresh tokens", async () => {
+  const service = new TokenService();
+  const repo = repoInstance;
+  const token = "refresh-super-secreto";
+
+  await service.save(token, "user-1");
+  assert.equal(repo.saved.length, 1);
+  const saved = repo.saved[0];
+  assert.notEqual(saved.token, token);
+  assert.equal(saved.token.length, 64);
+  assert.equal(saved.userId, "user-1");
+
+  const ok = await service.isValid(token);
+  assert.equal(ok, true);
+  assert.equal(repo.validated.at(-1), saved.token);
+
+  const issued = await service.wasIssued(token);
+  assert.equal(issued, true);
+  assert.equal(repo.issued.at(-1), saved.token);
+
+  await service.revoke(token);
+  assert.equal(repo.revoked.at(-1), saved.token);
+
+  await service.revokeAllForUser("user-1");
+  assert.equal(repo.revokedAllForUser.at(-1), "user-1");
+});
+
+test("TokenService rejeita tokens desconhecidos mesmo após hash", async () => {
+  const service = new TokenService();
+  const repo = repoInstance;
+  repo.saved = [];
+
+  const unknown = "refresh-desconhecido";
+  const ok = await service.isValid(unknown);
+  assert.equal(ok, false);
+  assert.equal(repo.validated.at(-1)?.length, 64);
+
+  const issued = await service.wasIssued(unknown);
+  assert.equal(issued, false);
+  assert.equal(repo.issued.at(-1)?.length, 64);
+});

--- a/technomoney-fake-api/README.md
+++ b/technomoney-fake-api/README.md
@@ -1,7 +1,7 @@
 
 # Technomoney Fake Market API
 
-Serviço auxiliar em Node.js/Express que simula uma API de dados de mercado para alimentar o dashboard e a carteira. Os preços e métricas são atualizados a cada 30 segundos, preservando campos fundamentais necessários para a experiência do front-end.
+Serviço auxiliar em Node.js/Express que simula uma API de dados de mercado para alimentar o dashboard, a carteira e a tela de detalhes de ações. Os preços e métricas são atualizados a cada 30 segundos, preservando campos fundamentais necessários para a experiência do front-end.
 
 ## Endpoints
 - `GET /acoes/all`: devolve a lista completa de ativos com métricas diárias, fundamentos e metadados (texto analítico, notícias e série histórica).


### PR DESCRIPTION
## Summary
- ensure the API automatically registers tickers exposed by the fake market feed without touching existing rows and extend the asset service tests
- wire the stock detail route to fetch `/assets/:tag`, render fundamentals/news from the backend and drop all front-end mocks, updating shared styles and helper services
- document the new data flow, fake API usage and add a security-focused token service test in the authenticator

## Testing
- `npm test` (technomoney-api)
- `npm test` (technomoney-auth)
- `npm test -- --watchAll=false` *(fails: react-scripts command not available in this Vite workspace)*


------
https://chatgpt.com/codex/tasks/task_b_68fab8aa2020832f941afad43dec2ef2