### PR TITLE
Document docker-compose setup and add redis service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,74 @@
 # Technomoney-SENAI
-Protótipo da Technomoney destinada a avaliação do SENAI
+Protótipo da Technomoney destinada à avaliação do SENAI, composto por múltiplos
+microsserviços Node.js/TypeScript com ênfase em autenticação forte (AAL2),
+proteções antifraude e consumo de dados de mercado.
+
+## Visão geral da documentação
+
+Todos os serviços possuem README próprio com fluxos, variáveis de ambiente e
+orientações de segurança revisadas. Utilize a tabela abaixo para localizar cada
+documento:
+
+| Serviço | Responsabilidade | Documentação |
+| --- | --- | --- |
+| `technomoney-auth` | Autenticação/OAuth2 + MFA TOTP, sessões e WebSocket | [`technomoney-auth/README.md`](technomoney-auth/README.md) |
+| `technomoney-api` | Domínio de ativos, sincronização com mercado e middleware de autorização | [`technomoney-api/README.md`](technomoney-api/README.md) |
+| `technomoney-payment-api` | Integração com Mercado Pago, webhooks assinados e validação de tokens | [`technomoney-payment-api/README.md`](technomoney-payment-api/README.md) |
+| `technomoney-ia` | Serviço heurístico de análise fundamentalista protegido por introspecção | [`technomoney-ia/README.md`](technomoney-ia/README.md) |
+| `technomoney-app` | Front-end React/Vite com MFA, carteira e painel de ativos | [`technomoney-app/README.md`](technomoney-app/README.md) |
+| `technomoney-fake-api` | Mock seguro para dados de mercado utilizados em desenvolvimento | [`technomoney-fake-api/README.md`](technomoney-fake-api/README.md) |
+
+Os READMEs foram validados para cobrir:
+
+- fluxos de segurança (CSRF, MFA, rate limiting e introspecção OAuth2);
+- listas completas de variáveis de ambiente e boas práticas de armazenamento de
+  segredos;
+- instruções de execução local (npm scripts) e, quando aplicável, testes
+  automatizados;
+- contratos de API e restrições de autenticação exigidas pelos consumidores.
+
+## Execução com Docker Compose central
+
+O repositório inclui um `docker-compose.yml` na raiz que sobe Postgres, Redis e
+os microsserviços principais (auth, API de domínio, pagamentos e serviço de IA)
+em uma única orquestração. Para utilizá-lo:
+
+1. Copie cada `prod.env` para `.env` dentro de seu respectivo diretório e
+   preencha segredos exclusivos para o ambiente (ex.: `technomoney-auth/prod.env`
+   → `technomoney-auth/.env`).
+2. Garanta que `technomoney-auth/.env` contenha chaves fortes (`TOTP_ENC_KEY`,
+   `TRUSTED_DEVICE_SECRET`, credenciais do banco e `REDIS_URL` já apontando
+   para `redis://redis:6379/0`).
+3. Opcionalmente execute a fake API de mercado separadamente (não faz parte do
+   compose) e ajuste `MARKET_API_BASE_URL` para apontar para ela.
+
+### Serviços orquestrados
+
+| Serviço | Porta | Descrição |
+| --- | --- | --- |
+| `redis` | `6379` | Cache usado pelo autenticador para trusted devices, rate limiting e anti-replay TOTP. |
+| `postgres` | `5432` | Banco compartilhado para autenticador, API principal e pagamentos (migrations aplicadas automaticamente). |
+| `auth` | `4000` | Autenticador com `INTROSPECTION_CLIENTS` pré-configurados (`core-service`, `payments-service`, `ia-service`). |
+| `api` | `4002` | API de ativos apontando para o autenticador via `/oauth2/introspect`. |
+| `payments` | `3001` | API de pagamentos com introspecção obrigatória. |
+| `ia-agent` | `4010` | Serviço de IA consumindo a introspecção do autenticador. |
+
+> ⚠️ `technomoney-fake-api` e `technomoney-app` não estão inclusos no compose
+> atual; suba-os separadamente quando precisar do front-end ou dos dados de
+> mercado simulados.
+
+### Comandos úteis
+
+```bash
+# Construir imagens e subir tudo em segundo plano
+docker compose up --build -d
+
+# Acompanhar logs
+docker compose logs -f
+
+# Encerrar e remover containers/volumes efêmeros
+docker compose down
+```
 
 ## Configuração do `TOTP_ENC_KEY`
 
@@ -7,9 +76,8 @@ O serviço de autenticação exige que a variável de ambiente `TOTP_ENC_KEY` se
 definida com um segredo forte para criptografar os segredos de TOTP. Utilize uma
 string com pelo menos 32 caracteres misturando letras maiúsculas, minúsculas,
 números e símbolos. Um exemplo de configuração pode ser encontrado em
-[`technomoney-auth/.env.example`](technomoney-auth/.env.example). Substitua esse
-valor por outro gerado especificamente para o seu ambiente antes de ir para
-produção.
+[`technomoney-auth/prod.env`](technomoney-auth/prod.env). Substitua esse valor
+por outro gerado especificamente para o seu ambiente antes de ir para produção.
 
 ## `technomoney-auth`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,13 @@
 version: "3.9"
 services:
+  redis:
+    image: redis:7-alpine
+    container_name: technomoney-redis
+    command: redis-server --save "" --appendonly no
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+
   postgres:
     image: postgres:16-alpine
     container_name: technomoney-postgres
@@ -19,26 +27,6 @@ services:
       timeout: 5s
       retries: 10
 
-  api:
-    build:
-      context: ./technomoney-api
-    container_name: technomoney-api
-    env_file:
-      - ./technomoney-api/.env
-    environment:
-      NODE_ENV: production
-      PORT: "4002"
-      SWAGGER_FILE: /app/dist/openapi.yaml
-      MARKET_API_BASE_URL: "http://host.docker.internal:4001"
-    ports:
-      - "4002:4002"
-    restart: unless-stopped
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-      postgres:
-        condition: service_healthy
-
   auth:
     build:
       context: ./technomoney-auth
@@ -57,18 +45,46 @@ services:
       DB_USERNAME: technomoney
       DB_PASSWORD: technopass
       DB_DATABASE: technomoney_auth
+      REDIS_URL: "redis://redis:6379/0"
+      INTROSPECTION_CLIENTS: "core-service:core-secret,payments-service:payments-secret,ia-service:ia-secret"
     ports:
       - "4000:4000"
     restart: unless-stopped
     depends_on:
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_started
     command: >
       sh -lc "
       node -e \"require('child_process').execSync('npx sequelize-cli db:migrate',{stdio:'inherit'})\" &&
-      redis-server --save '' --appendonly no --daemonize yes &&
       node ${ENTRY_FILE}
       "
+
+  api:
+    build:
+      context: ./technomoney-api
+    container_name: technomoney-api
+    env_file:
+      - ./technomoney-api/.env
+    environment:
+      NODE_ENV: production
+      PORT: "4002"
+      SWAGGER_FILE: /app/dist/openapi.yaml
+      MARKET_API_BASE_URL: "http://host.docker.internal:4001"
+      AUTH_INTROSPECTION_URL: "http://auth:4000/oauth2/introspect"
+      AUTH_INTROSPECTION_CLIENT_ID: core-service
+      AUTH_INTROSPECTION_CLIENT_SECRET: core-secret
+    ports:
+      - "4002:4002"
+    restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      auth:
+        condition: service_started
 
   payments:
     build:
@@ -85,12 +101,17 @@ services:
       DB_USERNAME: technomoney
       DB_PASSWORD: technopass
       DB_DATABASE: technomoney_auth
+      AUTH_INTROSPECTION_URL: "http://auth:4000/oauth2/introspect"
+      AUTH_INTROSPECTION_CLIENT_ID: payments-service
+      AUTH_INTROSPECTION_CLIENT_SECRET: payments-secret
     ports:
       - "3001:3001"
     restart: unless-stopped
     depends_on:
       postgres:
         condition: service_healthy
+      auth:
+        condition: service_started
 
   ia-agent:
     build:
@@ -101,9 +122,11 @@ services:
     environment:
       NODE_ENV: production
       PORT: "4010"
-      AUTH_INTROSPECTION_URL: "http://auth:4000/api/oauth2/introspect"
+      AUTH_INTROSPECTION_URL: "http://auth:4000/oauth2/introspect"
       RATE_LIMIT_WINDOW_MS: "60000"
       RATE_LIMIT_MAX: "60"
+      AUTH_INTROSPECTION_CLIENT_ID: ia-service
+      AUTH_INTROSPECTION_CLIENT_SECRET: ia-secret
     ports:
       - "4010:4010"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- add a dedicated Redis container and wire introspection credentials in the central docker-compose
- document how to prepare .env files and run the multi-service stack, referencing each service README
- clarify the TOTP secret guidance in the root README to point at the maintained prod.env template

## Testing
- not run (documentation and configuration only)


------
https://chatgpt.com/codex/tasks/task_b_690938115468832faed6241685b813e7