### PR TITLE
Fix auth TypeScript build and add email sanitization tests

### DIFF
--- a/technomoney-auth/README.md
+++ b/technomoney-auth/README.md
@@ -142,6 +142,20 @@ lista completa e recomendações de segurança comentadas.
 - Documento detalhado em PDF: [`docs/authentication-backend.pdf`](docs/authentication-backend.pdf)
 - Fluxograma do fluxo completo (Mermaid): [`docs/authentication-flowchart.mmd`](docs/authentication-flowchart.mmd)
 
+## Testes automatizados focados em segurança
+
+- Execute `npm test` para rodar a suíte de unidade com `node:test`. As fixtures em
+  `src/services/__tests__/email.service.spec.ts` garantem que os templates de
+  e-mail sejam sanitizados contra tentativas de header injection (remoção de
+  caracteres `\r` e limitação de quebras consecutivas).
+- Os testes de recuperação (`auth.service.recovery.spec.ts`) conferem que links
+  assinados usam tokens únicos com hash Argon2 e TTL limitado, reforçando MFA e
+  step-up ao revogar sessões ativas após resets.
+- Os cenários de trusted devices e TOTP sob `src/services/__tests__` validam que
+  o serviço mantém `acr=aal2` somente quando os cookies assinados e o Redis
+  retornam metadados íntegros, assegurando downgrade seguro em falhas de
+  infraestrutura.
+
 ## Integração com serviços consumidores
 
 - **`technomoney-payment-api`**: valida tokens via `/oauth2/introspect`. Tokens

--- a/technomoney-auth/src/controllers/__tests__/totp.controller.spec.ts
+++ b/technomoney-auth/src/controllers/__tests__/totp.controller.spec.ts
@@ -3,13 +3,20 @@ import test from "node:test";
 import path from "node:path";
 import Module from "module";
 
+type ModuleWithGlobalPaths = typeof Module & {
+  globalPaths?: string[];
+  _initPaths?: () => void;
+};
+
 const ensureStubPath = () => {
   const stubPath = path.resolve(__dirname, "../../../test-shims/node_modules");
-  if (!Module.globalPaths.includes(stubPath)) {
+  const moduleWithPaths = Module as ModuleWithGlobalPaths;
+  const paths = moduleWithPaths.globalPaths ?? [];
+  if (!paths.includes(stubPath)) {
     process.env.NODE_PATH = process.env.NODE_PATH
       ? `${stubPath}${path.delimiter}${process.env.NODE_PATH}`
       : stubPath;
-    Module._initPaths();
+    moduleWithPaths._initPaths?.();
   }
 };
 

--- a/technomoney-auth/src/services/__tests__/auth.service.recovery.spec.ts
+++ b/technomoney-auth/src/services/__tests__/auth.service.recovery.spec.ts
@@ -43,7 +43,52 @@ stubModule("../../models", {
 });
 
 import { AuthService } from "../auth.service";
+import { EmailService, MailPayload } from "../email.service";
 import { hashPassword, comparePassword } from "../../utils/password.util";
+
+type EmailRecord = {
+  template: "reset" | "verify";
+  to: string;
+  link: string;
+  expiresAt: Date;
+};
+
+class RecordingEmailService extends EmailService {
+  constructor(
+    private readonly events: EmailRecord[],
+    private readonly payloads: MailPayload[]
+  ) {
+    super({
+      async send(message) {
+        payloads.push(message);
+      },
+    });
+  }
+
+  async sendPasswordReset(
+    to: string,
+    link: string,
+    expiresAt: Date
+  ): Promise<void> {
+    this.events.push({ template: "reset", to, link, expiresAt });
+    await super.sendPasswordReset(to, link, expiresAt);
+  }
+
+  async sendEmailVerification(
+    to: string,
+    link: string,
+    expiresAt: Date
+  ): Promise<void> {
+    this.events.push({ template: "verify", to, link, expiresAt });
+    await super.sendEmailVerification(to, link, expiresAt);
+  }
+}
+
+const createEmailRecorder = () => {
+  const events: EmailRecord[] = [];
+  const payloads: MailPayload[] = [];
+  return { events, payloads, service: new RecordingEmailService(events, payloads) };
+};
 
 test("requestPasswordReset persiste token único e envia e-mail", async () => {
   const fixedNow = new Date("2025-01-01T00:00:00Z");
@@ -57,7 +102,7 @@ test("requestPasswordReset persiste token único e envia e-mail", async () => {
     email_verified: false,
   };
   const created: any[] = [];
-  const emails: any[] = [];
+  const { events: emails, service: emailService } = createEmailRecorder();
   const service = new AuthService({
     userRepository: {
       async findByEmail(email: string) {
@@ -74,12 +119,7 @@ test("requestPasswordReset persiste token único e envia e-mail", async () => {
         return data;
       },
     } as any,
-    emailService: {
-      async sendPasswordReset(to: string, link: string, expiresAt: Date) {
-        emails.push({ to, link, expiresAt });
-      },
-      async sendEmailVerification() {},
-    },
+    emailService,
     now: () => new Date(fixedNow),
   });
 
@@ -87,6 +127,7 @@ test("requestPasswordReset persiste token único e envia e-mail", async () => {
 
   assert.equal(created.length, 1);
   assert.equal(emails.length, 1);
+  assert.equal(emails[0].template, "reset");
   assert.equal(emails[0].to, user.email);
   const url = new URL(emails[0].link);
   const token = url.searchParams.get("token");
@@ -199,7 +240,7 @@ test("requestEmailVerification envia link seguro", async () => {
     email_verified: false,
   };
   const created: any[] = [];
-  const emails: any[] = [];
+  const { events: emails, service: emailService } = createEmailRecorder();
   const service = new AuthService({
     userRepository: {
       async findByEmail(email: string) {
@@ -216,18 +257,14 @@ test("requestEmailVerification envia link seguro", async () => {
         return data;
       },
     } as any,
-    emailService: {
-      async sendPasswordReset() {},
-      async sendEmailVerification(to: string, link: string, expiresAt: Date) {
-        emails.push({ to, link, expiresAt });
-      },
-    },
+    emailService,
   });
 
   await service.requestEmailVerification(user.email);
 
   assert.equal(created.length, 1);
   assert.equal(emails.length, 1);
+  assert.equal(emails[0].template, "verify");
   const token = new URL(emails[0].link).searchParams.get("token");
   assert.ok(token);
   const [tokenId, secret] = token!.split(".");

--- a/technomoney-auth/src/services/__tests__/email.service.spec.ts
+++ b/technomoney-auth/src/services/__tests__/email.service.spec.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EmailService, MailPayload } from "../email.service";
+
+test("sendPasswordReset sanitiza quebras de linha para evitar header injection", async () => {
+  const messages: MailPayload[] = [];
+  const service = new EmailService({
+    async send(message) {
+      messages.push(message);
+    },
+  });
+
+  const maliciousLink = "https://app.example/reset\n\n\nhttps://evil";
+  const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
+
+  await service.sendPasswordReset("user@example.com", maliciousLink, expiresAt);
+
+  assert.equal(messages.length, 1);
+  const payload = messages[0];
+  assert.equal(payload.to, "user@example.com");
+  assert.equal(payload.subject, "Recuperação de senha");
+  assert.equal(payload.text.includes("\r"), false, "texto não deve conter CR");
+  assert.equal(
+    payload.text.includes("\n\n\n"),
+    false,
+    "texto não deve preservar mais que duas quebras consecutivas"
+  );
+  assert.ok(
+    payload.text.includes("https://app.example/reset\n\nhttps://evil"),
+    "link deve ser preservado com sanitização controlada"
+  );
+});
+
+test("sendEmailVerification preserva mensagem e mantém sanitização", async () => {
+  const messages: MailPayload[] = [];
+  const service = new EmailService({
+    async send(message) {
+      messages.push(message);
+    },
+  });
+
+  const link = "https://app.example/verify?token=abc123";
+  const expiresAt = new Date(Date.now() + 10 * 60 * 1000);
+
+  await service.sendEmailVerification("verify@example.com", link, expiresAt);
+
+  assert.equal(messages.length, 1);
+  const payload = messages[0];
+  assert.equal(payload.to, "verify@example.com");
+  assert.equal(payload.subject, "Confirmação de e-mail");
+  assert.equal(payload.text.includes("\r"), false);
+  assert.ok(payload.text.includes(link));
+  assert.ok(
+    payload.text.includes("Confirme seu endereço de e-mail"),
+    "mensagem base deve ser mantida"
+  );
+});

--- a/technomoney-auth/src/services/__tests__/trusted-device.service.spec.ts
+++ b/technomoney-auth/src/services/__tests__/trusted-device.service.spec.ts
@@ -3,13 +3,20 @@ import test from "node:test";
 import path from "node:path";
 import Module from "module";
 
+type ModuleWithGlobalPaths = typeof Module & {
+  globalPaths?: string[];
+  _initPaths?: () => void;
+};
+
 const ensureStubPath = () => {
   const stubPath = path.resolve(__dirname, "../../../test-shims/node_modules");
-  if (!Module.globalPaths.includes(stubPath)) {
+  const moduleWithPaths = Module as ModuleWithGlobalPaths;
+  const paths = moduleWithPaths.globalPaths ?? [];
+  if (!paths.includes(stubPath)) {
     process.env.NODE_PATH = process.env.NODE_PATH
       ? `${stubPath}${path.delimiter}${process.env.NODE_PATH}`
       : stubPath;
-    Module._initPaths();
+    moduleWithPaths._initPaths?.();
   }
 };
 

--- a/technomoney-auth/src/utils/log/__tests__/log.helpers.spec.ts
+++ b/technomoney-auth/src/utils/log/__tests__/log.helpers.spec.ts
@@ -43,7 +43,10 @@ test("safeErr includes stack and nested cause when verbose errors enabled", (t) 
 
   assert.equal(payload.message, "boom");
   assert.equal(typeof payload.stack, "string");
-  assert.ok(payload.stack.includes("boom"));
+  assert.ok(
+    typeof payload.stack === "string" && payload.stack.includes("boom"),
+    "stack deve conter a mensagem original"
+  );
   assert.ok(payload.cause && typeof payload.cause === "object");
   assert.equal((payload.cause as Record<string, unknown>).message, "root cause");
   assert.ok(

--- a/technomoney-auth/tsconfig.json
+++ b/technomoney-auth/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES6",
     "module": "commonjs",
+    "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
@@ -13,5 +14,5 @@
       "@technomoney/types/*": ["../types/*"]
     }
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "../types/**/*.d.ts"]
 }


### PR DESCRIPTION
## Summary
- relax module path shims in TOTP and trusted device specs to compile on Node 22
- point TypeScript to shared express types and refactor recovery specs to use a typed email recorder
- document security-focused test coverage and add email service unit tests that guard against header injection

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_b_6909448cb5b0832fbb89c93ecfefec15