### PR TITLE
Fix technomoney-auth build by vendoring Express types

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ por outro gerado especificamente para o seu ambiente antes de ir para produção
 - Tokens de acesso assinados com DPoP agora carregam `cnf.jkt` no resultado da
   introspecção. Somente objetos simples com `jkt` em formato de string são
   expostos para evitar poluição do contrato.
+- Tipagens de usuário autenticado passaram a viver dentro de
+  `technomoney-auth/src/types/technomoney-authenticated-user.ts`, permitindo que
+  os builds Docker não dependam de diretórios externos para validar `acr`/`amr`
+  e reduzindo risco de regressões de segurança durante orquestrações isoladas.
 - Configure os novos segredos de introspecção:
   - `INTROSPECTION_CLIENTS`: lista separada por vírgula no formato
     `clientId:clientSecret`. Utilize senhas fortes por cliente que precise

--- a/technomoney-auth/README.md
+++ b/technomoney-auth/README.md
@@ -33,6 +33,12 @@ restritivo, cookies seguros e forçamento de HTTPS).
   `acr=aal2`, `amr` deduplicados e claims `trusted_device*`, preservando
   evidência do segundo fator sem reemitir códigos TOTP a cada autenticação mesmo
   durante indisponibilidade temporária do Redis.
+- **Tipagens endurecidas no build**: as definições de usuário autenticado foram
+  incorporadas a `src/types/technomoney-authenticated-user.ts`, garantindo que
+  os builds Docker do serviço mantenham validação consistente de claims sem
+  depender de caminhos externos ao contexto. Isso impede que middlewares como
+  `requireAAL2` percam verificações críticas de `acr`/`amr` quando o container é
+  reconstruído em ambientes isolados.
 
 - **OIDC completo**: suporte a PAR + PKCE (code flow), ID Token assinado com as
   mesmas chaves do acesso, opção de exigir DPoP (`REQUIRE_DPOP=true`) e
@@ -121,6 +127,7 @@ restritivo, cookies seguros e forçamento de HTTPS).
 | `SWAGGER_FILE` | Opcional | Mantém o caminho do OpenAPI servido pelo Swagger UI. Recomendado manter em `dist/openapi.yaml`.
 | `NODE_ENV` | Sim | Defina `production` em produção para reforçar cookies, HTTPS e validações.
 | `TOTP_ENC_KEY` | Sim | Chave forte (≥32 chars misturando classes) usada para AES-256-GCM dos segredos TOTP.
+| `TOTP_ISSUER` | Opcional | Nome apresentado nos apps de TOTP; escolha um rótulo sem dados sensíveis e que diferencie ambientes.
 | `REDIS_URL` | Sim em produção | Redis utilizado por rate limits, trusted devices e antifraude TOTP.
 | `TRUSTED_DEVICE_SECRET` | Recomendado | Segredo com ≥32 caracteres usado para assinar o cookie `tdmeta`. Quando ausente, o serviço deriva um HMAC da chave privada ativa do JWT.
 | `JWT_KEYS_DIR`/`JWT_PRIVATE_KEY`/`JWT_PUBLIC_KEY` | Sim | Fonte das chaves que assinam/verificam tokens. Sempre proteja o PEM privado.

--- a/technomoney-auth/prod.env
+++ b/technomoney-auth/prod.env
@@ -11,6 +11,8 @@ TRUSTED_DEVICE_SECRET=
 
 # Provide a strong value with at least 32 mixed characters before deploying
 TOTP_ENC_KEY=
+# Nome exibido nos aplicativos autenticadores (sem dados sensíveis).
+TOTP_ISSUER=Technomoney
 # TTL in seconds (min 60, max 3600) used to prevent MFA code replay
 TOTP_REPLAY_TTL=300
 JWT_REFRESH_SECRET=ASJKFLJKAFIUEUAOE

--- a/technomoney-auth/src/middlewares/__tests__/requireAAL2.middleware.spec.ts
+++ b/technomoney-auth/src/middlewares/__tests__/requireAAL2.middleware.spec.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { Request, Response, NextFunction } from "express";
+
+import {
+  requireAAL2,
+  resetTotpService,
+  setTotpService,
+} from "../requireAAL2.middleware";
+
+type MutableResponse = Response & {
+  statusCode?: number;
+  body?: unknown;
+};
+
+test("allows requests when acr already satisfies aal2", async () => {
+  const req = buildRequest({ acr: "aal2" });
+  const res = buildResponse();
+  const flags = { calledNext: false };
+  const next: NextFunction = () => {
+    flags.calledNext = true;
+  };
+
+  await requireAAL2(req, res, next);
+
+  assert.equal(flags.calledNext, true);
+  assert.equal(res.statusCode, undefined);
+});
+
+test("rejects when user is missing", async () => {
+  const req = buildRequest(undefined);
+  const res = buildResponse();
+  const flags = { calledNext: false };
+
+  await requireAAL2(req, res, () => {
+    flags.calledNext = true;
+  });
+
+  assert.equal(flags.calledNext, false);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, { stepUp: "login" });
+});
+
+test("requests step-up totp when enrollment exists", async () => {
+  const req = buildRequest({ id: "user-1", acr: "aal1" });
+  const res = buildResponse();
+  const flags = { calledNext: false };
+
+  setTotpService({
+    async status(userId: string) {
+      assert.equal(userId, "user-1");
+      return true;
+    },
+  });
+
+  await requireAAL2(req, res, () => {
+    flags.calledNext = true;
+  });
+
+  assert.equal(flags.calledNext, false);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, { stepUp: "totp" });
+
+  resetTotpService();
+});
+
+test("requests totp enrollment when no second factor is active", async () => {
+  const req = buildRequest({ id: "user-2", acr: "aal1" });
+  const res = buildResponse();
+  const flags = { calledNext: false };
+
+  setTotpService({
+    async status(userId: string) {
+      assert.equal(userId, "user-2");
+      return false;
+    },
+  });
+
+  await requireAAL2(req, res, () => {
+    flags.calledNext = true;
+  });
+
+  assert.equal(flags.calledNext, false);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, { stepUp: "enroll", options: ["totp"] });
+
+  resetTotpService();
+});
+
+function buildRequest(user?: Partial<Request["user"]>) {
+  return {
+    user: user as Request["user"],
+  } as Request;
+}
+
+function buildResponse(): MutableResponse {
+  const res: Partial<MutableResponse> = {};
+  res.status = (code: number) => {
+    res.statusCode = code;
+    return res as MutableResponse;
+  };
+  res.json = (body: unknown) => {
+    res.body = body;
+    return res as MutableResponse;
+  };
+  return res as MutableResponse;
+}

--- a/technomoney-auth/src/middlewares/requireAAL2.middleware.ts
+++ b/technomoney-auth/src/middlewares/requireAAL2.middleware.ts
@@ -1,11 +1,20 @@
 import type { Request, Response, NextFunction } from "express";
-import type { TechnomoneyAuthenticatedUser } from "@technomoney/types/express";
+import type { TechnomoneyAuthenticatedUser } from "../types/technomoney-authenticated-user";
 
 import { TotpService } from "../services/totp.service";
 
+type TotpStatusProvider = Pick<TotpService, "status">;
+
 type RequestWithUser = Request & { user?: TechnomoneyAuthenticatedUser };
 
-const totp = new TotpService();
+let totp: TotpStatusProvider = new TotpService();
+
+export const setTotpService = (override: TotpStatusProvider) => {
+  if (!override || typeof override.status !== "function") {
+    throw new Error("setTotpService requires an object implementing status(userId)");
+  }
+  totp = override;
+};
 
 export const requireAAL2 = async (
   req: RequestWithUser,
@@ -27,4 +36,8 @@ export const requireAAL2 = async (
     return;
   }
   res.status(401).json({ stepUp: "enroll", options: ["totp"] });
+};
+
+export const resetTotpService = () => {
+  totp = new TotpService();
 };

--- a/technomoney-auth/src/types/express.d.ts
+++ b/technomoney-auth/src/types/express.d.ts
@@ -1,4 +1,4 @@
-import type { TechnomoneyAuthenticatedUser } from "@technomoney/types/express";
+import type { TechnomoneyAuthenticatedUser } from "./technomoney-authenticated-user";
 
 declare global {
   namespace Express {

--- a/technomoney-auth/src/types/technomoney-authenticated-user.ts
+++ b/technomoney-auth/src/types/technomoney-authenticated-user.ts
@@ -1,0 +1,12 @@
+export type TechnomoneyAuthenticatedUser = {
+  id: string;
+  jti: string;
+  scope: string[];
+  payload?: Record<string, unknown>;
+  acr?: string;
+  username?: string;
+  exp?: number;
+  token?: string;
+  amr?: string[];
+  email?: string;
+};


### PR DESCRIPTION
## Summary
- bundle the authenticated user Express typings inside technomoney-auth and allow requireAAL2 to swap the TOTP provider for testing
- add coverage for the AAL2 middleware scenarios and keep documentation aligned with the hardened build flow
- document the new TOTP_ISSUER variable so production environments advertise safe issuer labels

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_69094666c9d4832fa9099678fa7694a6