### PR TITLE
Fix Sequelize config lookup for production auth builds

### DIFF
--- a/technomoney-auth/.sequelizerc
+++ b/technomoney-auth/.sequelizerc
@@ -1,7 +1,33 @@
+const fs = require("fs");
 const path = require("path");
+
+const rawHints = process.env.SEQUELIZE_DIR_HINT;
+const searchRoots = (rawHints && rawHints.length > 0
+  ? rawHints.split(path.delimiter)
+  : ["dist", "src"]) // Default: prefer build artefacts, fallback to sources.
+  .map((rootCandidate) => path.resolve(rootCandidate))
+  // Remove duplicates while preserving order to avoid redundant fs checks.
+  .filter((rootCandidate, index, array) => array.indexOf(rootCandidate) === index);
+
+if (searchRoots.length === 0) {
+  searchRoots.push(path.resolve("src"));
+}
+
+const fallbackRoot = path.resolve("src");
+
+function resolveSequelizePath(...segments) {
+  for (const rootDir of searchRoots) {
+    const candidate = path.join(rootDir, ...segments);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return path.join(fallbackRoot, ...segments);
+}
+
 module.exports = {
-  config: path.resolve("src", "config", "config.js"),
-  "models-path": path.resolve("src", "models"),
-  "seeders-path": path.resolve("src", "seeders"),
-  "migrations-path": path.resolve("src", "migrations"),
+  config: resolveSequelizePath("config", "config.js"),
+  "models-path": resolveSequelizePath("models"),
+  "seeders-path": resolveSequelizePath("seeders"),
+  "migrations-path": resolveSequelizePath("migrations"),
 };

--- a/technomoney-auth/README.md
+++ b/technomoney-auth/README.md
@@ -125,6 +125,7 @@ restritivo, cookies seguros e forçamento de HTTPS).
 | `PORT` | Sim | Porta HTTP do serviço (default 4000).
 | `ENTRY_FILE` | Opcional | Define o arquivo JS compilado executado no container. Sem valor, `dist/server.js` é utilizado.
 | `SWAGGER_FILE` | Opcional | Mantém o caminho do OpenAPI servido pelo Swagger UI. Recomendado manter em `dist/openapi.yaml`.
+| `SEQUELIZE_DIR_HINT` | Opcional | Lista (separada por `:`) de diretórios a serem priorizados pelo CLI do Sequelize ao localizar `config.js`, models, migrations e seeders. Útil para forçar `dist` quando as migrações rodam após o build.
 | `NODE_ENV` | Sim | Defina `production` em produção para reforçar cookies, HTTPS e validações.
 | `TOTP_ENC_KEY` | Sim | Chave forte (≥32 chars misturando classes) usada para AES-256-GCM dos segredos TOTP.
 | `TOTP_ISSUER` | Opcional | Nome apresentado nos apps de TOTP; escolha um rótulo sem dados sensíveis e que diferencie ambientes.
@@ -143,6 +144,13 @@ restritivo, cookies seguros e forçamento de HTTPS).
 
 Consulte o arquivo [`technomoney-auth/prod.env`](technomoney-auth/prod.env) para a
 lista completa e recomendações de segurança comentadas.
+
+> **Dica de segurança para migrações:** o `.sequelizerc` agora procura primeiro
+> por artefatos compilados em `dist/` (ou nos caminhos fornecidos via
+> `SEQUELIZE_DIR_HINT`) antes de recorrer ao código-fonte em `src/`. Isso garante
+> que execuções de `npx sequelize-cli db:migrate` dentro do container usem a
+> mesma configuração versionada que entrou no build, reduzindo riscos de
+> divergência entre ambientes.
 
 ### Documentação complementar
 

--- a/technomoney-auth/prod.env
+++ b/technomoney-auth/prod.env
@@ -4,6 +4,9 @@ ENTRY_FILE=dist/server.js
 # Caminho do OpenAPI gerado no build (mantém a documentação servida via swagger).
 # Em containers utilize `/app/dist/openapi.yaml`.
 SWAGGER_FILE=dist/openapi.yaml
+# Ajuste o CLI do Sequelize para procurar primeiro nos diretórios informados
+# (separados por dois pontos). O padrão prioriza dist/ e recai para src/.
+SEQUELIZE_DIR_HINT=
 # Redis é obrigatório para rate limits, trusted devices e anti-replay do MFA.
 REDIS_URL=
 # 32+ caracteres randômicos usados para assinar o cookie tdmeta quando Redis estiver indisponível

--- a/technomoney-auth/src/config/__tests__/sequelizerc.resolution.spec.ts
+++ b/technomoney-auth/src/config/__tests__/sequelizerc.resolution.spec.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const projectRoot = path.resolve(__dirname, "..", "..", "..");
+const sequelizercPath = path.join(projectRoot, ".sequelizerc");
+
+function loadSequelizerc() {
+  delete require.cache[sequelizercPath];
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require(sequelizercPath);
+}
+
+test(".sequelizerc defaults to source tree when build artifacts are absent", () => {
+  const previousHint = process.env.SEQUELIZE_DIR_HINT;
+  delete process.env.SEQUELIZE_DIR_HINT;
+
+  try {
+    const config = loadSequelizerc();
+    assert.equal(
+      config.config,
+      path.join(projectRoot, "src", "config", "config.js"),
+      "config path should fall back to the TypeScript source tree",
+    );
+    assert.equal(
+      config["models-path"],
+      path.join(projectRoot, "src", "models"),
+      "models path should point to the TypeScript sources by default",
+    );
+    assert.equal(
+      config["migrations-path"],
+      path.join(projectRoot, "src", "migrations"),
+      "migrations path should default to the TypeScript sources",
+    );
+    assert.equal(
+      config["seeders-path"],
+      path.join(projectRoot, "src", "seeders"),
+      "seeders path should default to the TypeScript sources",
+    );
+  } finally {
+    if (previousHint) {
+      process.env.SEQUELIZE_DIR_HINT = previousHint;
+    } else {
+      delete process.env.SEQUELIZE_DIR_HINT;
+    }
+  }
+});
+
+test(".sequelizerc honors SEQUELIZE_DIR_HINT and prefers existing build folders", () => {
+  const previousHint = process.env.SEQUELIZE_DIR_HINT;
+  const artifactRoot = path.join(projectRoot, "__tmp_dist__");
+  const configDir = path.join(artifactRoot, "config");
+  const modelsDir = path.join(artifactRoot, "models");
+  const migrationsDir = path.join(artifactRoot, "migrations");
+  const seedersDir = path.join(artifactRoot, "seeders");
+
+  fs.rmSync(artifactRoot, { recursive: true, force: true });
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.mkdirSync(modelsDir, { recursive: true });
+  fs.mkdirSync(migrationsDir, { recursive: true });
+  fs.mkdirSync(seedersDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, "config.js"), "module.exports = {};");
+
+  process.env.SEQUELIZE_DIR_HINT = `${path.relative(projectRoot, artifactRoot)}${path.delimiter}src`;
+
+  try {
+    const config = loadSequelizerc();
+    assert.equal(
+      config.config,
+      path.join(configDir, "config.js"),
+      "config path should use the build artifact when SEQUELIZE_DIR_HINT is provided",
+    );
+    assert.equal(
+      config["models-path"],
+      modelsDir,
+      "models path should use the hinted build directory",
+    );
+    assert.equal(
+      config["migrations-path"],
+      migrationsDir,
+      "migrations path should use the hinted build directory",
+    );
+    assert.equal(
+      config["seeders-path"],
+      seedersDir,
+      "seeders path should use the hinted build directory",
+    );
+  } finally {
+    if (previousHint) {
+      process.env.SEQUELIZE_DIR_HINT = previousHint;
+    } else {
+      delete process.env.SEQUELIZE_DIR_HINT;
+    }
+    fs.rmSync(artifactRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- make `.sequelizerc` dynamically prefer build artefacts and honour the `SEQUELIZE_DIR_HINT` override so migrations keep working after Docker builds
- add unit coverage in the authenticator service to lock the new resolution rules in place
- document the new environment variable alongside migration guidance in the README and production env template

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_690948756000832fa56d9acf052acd07