### PR TITLE
Ensure Sequelize migrations use compiled config in production

### DIFF
--- a/technomoney-auth/Dockerfile
+++ b/technomoney-auth/Dockerfile
@@ -11,7 +11,6 @@ COPY tsconfig.json ./
 COPY src ./src
 RUN npm run build
 RUN if [ -d "src/models" ]; then mkdir -p dist/models && cp -r src/models/* dist/models/; fi
-RUN if [ -d "src/config" ]; then mkdir -p dist/config && cp -r src/config/* dist/config/; fi
 RUN if [ -d "src/migrations" ]; then mkdir -p dist/migrations && cp -r src/migrations/* dist/migrations/; fi
 RUN if [ -d "src/seeders" ]; then mkdir -p dist/seeders && cp -r src/seeders/* dist/seeders/; fi
 RUN if [ -f "src/openapi.yaml" ]; then cp src/openapi.yaml dist/openapi.yaml; fi

--- a/technomoney-auth/README.md
+++ b/technomoney-auth/README.md
@@ -168,7 +168,11 @@ Manter `/app/dist` como primeira entrada evita leituras de diretórios
 transientes (`/tmp`, volumes montados ou `/app/src`) que poderiam ser adulterados
 durante a publicação. Caso seja necessário incluir migrações adicionais via
 volume, acrescente o caminho extra após `/app/dist`, separado por `:`,
-preservando o build assinado como origem de confiança.
+preservando o build assinado como origem de confiança. Sempre execute `npm run`
+`build` antes de disparar `npx sequelize-cli ...` em ambientes sem `ts-node`
+instalado; o loader `src/config/config.js` passa a recorrer automaticamente ao
+artefato compilado (`dist/config/config.js`) quando a dependência de desenvolvimento
+não está disponível.
 
 ### Documentação complementar
 

--- a/technomoney-auth/scripts/run-tests.cjs
+++ b/technomoney-auth/scripts/run-tests.cjs
@@ -46,6 +46,7 @@ function run(command, args, options = {}) {
       "src/controllers/__tests__/totp.controller.spec.ts",
       "src/middlewares/__tests__/dpop.middleware.spec.ts",
       "src/config/__tests__/config.bridge.spec.ts",
+      "src/config/__tests__/config.loader.spec.ts",
       "src/services/__tests__/auth.service.recovery.spec.ts",
       "src/services/__tests__/auth.service.refresh.spec.ts",
       "src/services/__tests__/trusted-device.service.spec.ts",

--- a/technomoney-auth/src/config/__tests__/config.loader.spec.ts
+++ b/technomoney-auth/src/config/__tests__/config.loader.spec.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import Module from "node:module";
+import path from "node:path";
+import test from "node:test";
+
+const projectRoot = path.resolve(__dirname, "..", "..", "..");
+const loaderPath = path.join(projectRoot, "src", "config", "config.js");
+const compiledConfigPath = path.join(projectRoot, "dist", "config", "config.js");
+
+function withPatchedResolve(fn: () => void) {
+  const originalResolveFilename = (Module as unknown as { _resolveFilename: typeof Module._resolveFilename })._resolveFilename;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (Module as unknown as { _resolveFilename: typeof Module._resolveFilename })._resolveFilename = function patched(request: string, parent: any, isMain: boolean, options: any) {
+    if (request === "ts-node/register" || request === "ts-node") {
+      const error = new Error(`Cannot find module '${request}'`);
+      // @ts-expect-error - custom property used for compatibility with Node's module resolution.
+      error.code = "MODULE_NOT_FOUND";
+      throw error;
+    }
+
+    return originalResolveFilename.call(Module, request, parent, isMain, options);
+  };
+
+  try {
+    fn();
+  } finally {
+    (Module as unknown as { _resolveFilename: typeof Module._resolveFilename })._resolveFilename = originalResolveFilename;
+  }
+}
+
+test("config.js falls back to compiled artefact when ts-node is unavailable", () => {
+  const hadPrevious = fs.existsSync(compiledConfigPath);
+  const previousContent = hadPrevious ? fs.readFileSync(compiledConfigPath, "utf8") : undefined;
+
+  fs.mkdirSync(path.dirname(compiledConfigPath), { recursive: true });
+  fs.writeFileSync(
+    compiledConfigPath,
+    "module.exports = { development: { url: 'postgres://fallback-url' } };",
+  );
+
+  delete require.cache[loaderPath];
+  delete require.cache[compiledConfigPath];
+
+  try {
+    withPatchedResolve(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const loadedConfig = require(loaderPath);
+      assert.equal(
+        loadedConfig.development.url,
+        "postgres://fallback-url",
+        "should expose the compiled configuration when ts-node cannot be used",
+      );
+    });
+  } finally {
+    if (hadPrevious && previousContent !== undefined) {
+      fs.writeFileSync(compiledConfigPath, previousContent);
+    } else {
+      fs.rmSync(compiledConfigPath, { force: true });
+    }
+    delete require.cache[loaderPath];
+    delete require.cache[compiledConfigPath];
+  }
+});

--- a/technomoney-auth/src/config/config.js
+++ b/technomoney-auth/src/config/config.js
@@ -1,18 +1,67 @@
+const fs = require("fs");
 const path = require("path");
 
+const projectRoot = path.resolve(__dirname, "..", "..");
+const tsConfigPath = path.resolve(__dirname, "config.ts");
+
+let tsNodeAvailable = false;
 try {
   require.resolve("ts-node/register");
-  require("ts-node").register({
-    transpileOnly: true,
-    compilerOptions: {
-      module: "CommonJS",
-    },
-    project: path.resolve(__dirname, "..", "..", "tsconfig.json"),
-  });
+  tsNodeAvailable = true;
 } catch (error) {
-  // Ignore if ts-node is not installed; assume a compiled version is available.
+  if (error && error.code && error.code !== "MODULE_NOT_FOUND") {
+    throw error;
+  }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const config = require("./config.ts");
-module.exports = config.default || config;
+if (tsNodeAvailable) {
+  try {
+    require("ts-node").register({
+      transpileOnly: true,
+      compilerOptions: {
+        module: "CommonJS",
+      },
+      project: path.resolve(projectRoot, "tsconfig.json"),
+    });
+  } catch (error) {
+    if (error && error.code === "MODULE_NOT_FOUND") {
+      tsNodeAvailable = false;
+    } else {
+      throw error;
+    }
+  }
+}
+
+let configModule;
+if (tsNodeAvailable && fs.existsSync(tsConfigPath)) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  configModule = require(tsConfigPath);
+}
+
+if (!configModule) {
+  const fallbackCandidates = [
+    path.resolve(projectRoot, "dist", "config", "config.js"),
+  ];
+
+  for (const candidate of fallbackCandidates) {
+    const normalizedCandidate = path.resolve(candidate);
+    if (normalizedCandidate === path.resolve(__filename)) {
+      continue;
+    }
+    if (fs.existsSync(normalizedCandidate)) {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      configModule = require(normalizedCandidate);
+      break;
+    }
+  }
+}
+
+if (!configModule) {
+  const error = new Error(
+    "Unable to locate a compiled Sequelize configuration. Run `npm run build` before executing migrations.",
+  );
+  error.code = "ENOENT";
+  throw error;
+}
+
+module.exports = configModule.default || configModule;


### PR DESCRIPTION
## Summary
- update the Sequelize config loader to fall back to compiled artifacts when ts-node is not available
- remove the Docker build step that overwrote compiled config files and document the new workflow
- add a regression test for the loader fallback and include it in the node:test runner list

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_69094bf98108832fbe656687c67cccc8