### PR TITLE
Ensure technomoney-api applies migrations during container startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ em uma única orquestração. Para utilizá-lo:
 | `redis` | `6379` | Cache usado pelo autenticador para trusted devices, rate limiting e anti-replay TOTP. |
 | `postgres` | `5432` | Banco compartilhado para autenticador, API principal e pagamentos (migrations aplicadas automaticamente). |
 | `auth` | `4000` | Autenticador com `INTROSPECTION_CLIENTS` pré-configurados (`core-service`, `payments-service`, `ia-service`). |
-| `api` | `4002` | API de ativos apontando para o autenticador via `/oauth2/introspect`. |
+| `api` | `4002` | API de ativos apontando para o autenticador via `/oauth2/introspect` e aplicando migrations automaticamente na inicialização. |
 | `payments` | `3001` | API de pagamentos com introspecção obrigatória. |
 | `ia-agent` | `4010` | Serviço de IA consumindo a introspecção do autenticador. |
 
@@ -82,6 +82,11 @@ docker compose logs -f
 
 # Encerrar e remover containers/volumes efêmeros
 docker compose down
+
+# Os serviços aplicam migrations automaticamente quando sobem.
+# Para iniciar a API de domínio em modo read-only defina
+# SKIP_DB_MIGRATIONS=1 no arquivo de ambiente correspondente
+# ou exporte a variável antes do `docker compose up`.
 
 # O serviço `auth` aceita um arquivo de entrada customizado via `ENTRY_FILE`
 # (variável opcional no `.env`). Quando não definida ele executa `dist/server.js`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,13 @@ services:
       NODE_ENV: production
       PORT: "4002"
       SWAGGER_FILE: /app/dist/openapi.yaml
+      DB_DRIVER: postgres
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_USERNAME: technomoney
+      DB_PASSWORD: technopass
+      DB_DATABASE: technomoney_auth
+      SKIP_DB_MIGRATIONS: "${SKIP_DB_MIGRATIONS:-0}"
       MARKET_API_BASE_URL: "http://host.docker.internal:4001"
       AUTH_INTROSPECTION_URL: "http://auth:4000/oauth2/introspect"
       AUTH_INTROSPECTION_CLIENT_ID: core-service

--- a/technomoney-api/.sequelizerc
+++ b/technomoney-api/.sequelizerc
@@ -1,8 +1,14 @@
-const path = require('path');
+const path = require("path");
+
+const baseDir = process.env.SEQUELIZE_BASE_DIR
+  ? process.env.SEQUELIZE_BASE_DIR
+  : process.env.NODE_ENV === "production"
+    ? "dist"
+    : "src";
 
 module.exports = {
-  'config': path.resolve('src', 'config', 'config.js'),      // configurações do banco
-  'models-path': path.resolve('src', 'models'),              // models
-  'seeders-path': path.resolve('src', 'seeders'),            // seeders (se quiser)
-  'migrations-path': path.resolve('src', 'migrations'),      // migrations
+  config: path.resolve(baseDir, "config", "config.js"), // configurações do banco
+  "models-path": path.resolve(baseDir, "models"), // models
+  "seeders-path": path.resolve(baseDir, "seeders"), // seeders (se quiser)
+  "migrations-path": path.resolve(baseDir, "migrations"), // migrations
 };

--- a/technomoney-api/Dockerfile
+++ b/technomoney-api/Dockerfile
@@ -10,10 +10,10 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY tsconfig.json ./
 COPY src ./src
 RUN npm run build
-RUN if [ -d "src/models" ]; then mkdir -p dist/models && cp -r src/models/* dist/models/; fi
-RUN if [ -d "src/config" ]; then mkdir -p dist/config && cp -r src/config/* dist/config/; fi
-RUN if [ -d "src/migrations" ]; then mkdir -p dist/migrations && cp -r src/migrations/* dist/migrations/; fi
-RUN if [ -d "src/seeders" ]; then mkdir -p dist/seeders && cp -r src/seeders/* dist/seeders/; fi
+RUN if [ -d "src/models" ]; then mkdir -p dist/models && cp -r src/models/. dist/models/; fi
+RUN if [ -d "src/config" ]; then mkdir -p dist/config && cp -r src/config/. dist/config/; fi
+RUN if [ -d "src/migrations" ]; then mkdir -p dist/migrations && cp -r src/migrations/. dist/migrations/; fi
+RUN if [ -d "src/seeders" ]; then mkdir -p dist/seeders && cp -r src/seeders/. dist/seeders/; fi
 RUN if [ -f "src/openapi.yaml" ]; then mkdir -p dist && cp src/openapi.yaml dist/openapi.yaml; fi
 
 FROM node:20-alpine AS runner

--- a/technomoney-api/Dockerfile
+++ b/technomoney-api/Dockerfile
@@ -12,6 +12,8 @@ COPY src ./src
 RUN npm run build
 RUN if [ -d "src/models" ]; then mkdir -p dist/models && cp -r src/models/* dist/models/; fi
 RUN if [ -d "src/config" ]; then mkdir -p dist/config && cp -r src/config/* dist/config/; fi
+RUN if [ -d "src/migrations" ]; then mkdir -p dist/migrations && cp -r src/migrations/* dist/migrations/; fi
+RUN if [ -d "src/seeders" ]; then mkdir -p dist/seeders && cp -r src/seeders/* dist/seeders/; fi
 RUN if [ -f "src/openapi.yaml" ]; then mkdir -p dist && cp src/openapi.yaml dist/openapi.yaml; fi
 
 FROM node:20-alpine AS runner
@@ -21,8 +23,11 @@ COPY package*.json ./
 COPY --from=deps /app/node_modules ./node_modules
 RUN npm prune --omit=dev
 COPY --from=build /app/dist ./dist
+COPY .sequelizerc ./.sequelizerc
+COPY docker/entrypoint.sh ./entrypoint.sh
+RUN chmod 550 entrypoint.sh
 ENV HOST=0.0.0.0
 ENV PORT=4002
 ENV SWAGGER_FILE=/app/dist/openapi.yaml
 EXPOSE 4002
-CMD ["node","dist/server.js"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/technomoney-api/README.md
+++ b/technomoney-api/README.md
@@ -41,6 +41,11 @@ A Technomoney API expõe endpoints responsáveis por orquestrar dados de mercado
    npm start
    ```
 
+7. **Execução em containers**
+   - O Dockerfile oficial executa `npx sequelize-cli db:migrate` automaticamente no start do container para garantir que o schema esteja sincronizado antes de receber tráfego.
+   - Para cenários onde o container deve iniciar em modo somente leitura (ex.: réplicas de análise), defina `SKIP_DB_MIGRATIONS=1` nas variáveis do serviço.
+   - O entrypoint também ajusta automaticamente o `SWAGGER_FILE` para `/app/dist/openapi.yaml` quando a variável não estiver definida, mantendo a documentação disponível sem expor caminhos inseguros.
+
 ## Variáveis de ambiente
 | Variável | Obrigatória | Descrição |
 | --- | --- | --- |
@@ -64,6 +69,7 @@ A Technomoney API expõe endpoints responsáveis por orquestrar dados de mercado
 | `AUTH_CLOCK_TOLERANCE` | Não | Folga (em segundos) para validação de exp/nbf. |
 | `AUTH_ALLOWED_ALGS` | Não | Lista separada por vírgulas dos algoritmos aceitos (ex.: `RS256,ES256`). |
 | `AUTH_STATIC_JWKS` | Não | JWKS estático (JSON) para contingência. Proteja e rotacione com rigor. |
+| `SKIP_DB_MIGRATIONS` | Não (default `0`) | Quando `1`, impede que o entrypoint aplique migrations automaticamente. Útil para réplicas read-only sob monitoramento. |
 
 > **Importante:** Não armazene segredos diretamente no repositório. Utilize `.env` apenas em desenvolvimento local e carregue valores em produção via variáveis de ambiente ou serviços de segredo.
 

--- a/technomoney-api/docker/entrypoint.sh
+++ b/technomoney-api/docker/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -euo pipefail
+
+if [ "${SKIP_DB_MIGRATIONS:-0}" = "1" ]; then
+  echo "[entrypoint] SKIP_DB_MIGRATIONS=1 detectado - pulando migrations."
+else
+  echo "[entrypoint] Aplicando migrations do banco de dados..."
+  node -e "require('child_process').execSync('npx sequelize-cli db:migrate', { stdio: 'inherit' });"
+  echo "[entrypoint] Migrations aplicadas com sucesso."
+fi
+
+if [ -z "${SWAGGER_FILE:-}" ] && [ -f "/app/dist/openapi.yaml" ]; then
+  export SWAGGER_FILE=/app/dist/openapi.yaml
+fi
+
+exec node "${ENTRY_FILE:-dist/server.js}"

--- a/technomoney-api/prod.env
+++ b/technomoney-api/prod.env
@@ -12,6 +12,8 @@ DB_USERNAME=
 DB_PASSWORD=
 DB_DATABASE=
 DB_DRIVER=postgres
+# Defina como "1" apenas se quiser iniciar o container sem executar migrations (ex.: pipelines read-only)
+SKIP_DB_MIGRATIONS=0
 
 # Integrações externas
 # Base HTTPS da API de mercado compatível com o contrato enriquecido (ticker, fundamentals, notícias)


### PR DESCRIPTION
## Summary
- add a hardened entrypoint for technomoney-api that runs Sequelize migrations before launching the server
- configure docker compose, environment templates, and documentation to describe the automatic migration flow and optional skip flag
- update the Sequelize resolver so production containers use the compiled assets when running migrations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_690bf1d47744832f9e7c31a2db122316