### PR TITLE
Fix TOTP enrollment after registration by keeping step-up context

### DIFF
--- a/technomoney-app/src/components/Login/Register.tsx
+++ b/technomoney-app/src/components/Login/Register.tsx
@@ -80,7 +80,11 @@ const Register: React.FC = () => {
     if (step !== "enroll_totp" && step !== "totp") return;
     const usernameHint = data?.username ?? null;
     if (data?.token) {
-      await login(data.token, usernameHint);
+      await login(data.token, usernameHint, {
+        stepUp: true,
+        acr: data?.acr ?? null,
+        source: "register",
+      });
     }
     setStepUp({ mode: step, usernameHint });
     setError("");


### PR DESCRIPTION
## Summary
- update the registration flow to mark the received step-up token as such when storing it in the auth context
- prevent the auth context from attempting websocket/refresh flows that drop the required step-up context before TOTP enrollment

## Testing
- CI=true npm test -- Register *(fails: react-scripts not found in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912737dc05c8327b55f20772bec78cf)