### PR TITLE
feat: add profile microservice and integrate frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       DB_PASSWORD: technopass
       DB_DATABASE: technomoney_auth
       REDIS_URL: "redis://redis:6379/0"
-      INTROSPECTION_CLIENTS: "core-service:core-secret,payments-service:payments-secret,ia-service:ia-secret"
+      INTROSPECTION_CLIENTS: "core-service:core-secret,payments-service:payments-secret,ia-service:ia-secret,profile-service:profile-secret"
     ports:
       - "4000:4000"
     restart: unless-stopped
@@ -91,6 +91,33 @@ services:
     restart: unless-stopped
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      auth:
+        condition: service_started
+
+  profile:
+    build:
+      context: ./technomoney-profile-api
+    container_name: technomoney-profile
+    environment:
+      NODE_ENV: production
+      PORT: "4003"
+      SWAGGER_FILE: /app/dist/openapi.yaml
+      DB_DRIVER: postgres
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_USERNAME: technomoney
+      DB_PASSWORD: technopass
+      DB_DATABASE: technomoney_auth
+      AUTH_INTROSPECTION_URL: "http://auth:4000/oauth2/introspect"
+      AUTH_INTROSPECTION_CLIENT_ID: profile-service
+      AUTH_INTROSPECTION_CLIENT_SECRET: profile-secret
+      CORS_ALLOWED_ORIGINS: "http://localhost:5173,http://localhost:3000"
+    ports:
+      - "4003:4003"
+    restart: unless-stopped
     depends_on:
       postgres:
         condition: service_healthy

--- a/technomoney-app/prod.env
+++ b/technomoney-app/prod.env
@@ -1,5 +1,6 @@
 # URLs base dos serviços (use sempre HTTPS em produção)
 VITE_API_URL=https://api.technomoney.local/api
+VITE_PROFILE_API_URL=https://profile.technomoney.local/api
 VITE_AUTH_API_URL=https://auth.technomoney.local/api
 VITE_PAYMENTS_API_URL=https://payments.technomoney.local/api/payments
 VITE_AI_AGENT_URL=https://ia.technomoney.local/api/ia

--- a/technomoney-app/src/App.tsx
+++ b/technomoney-app/src/App.tsx
@@ -11,6 +11,7 @@ import Register from "./components/Login/Register";
 import Dashboard from "./components/Dashboard/Dashboard";
 import PortfolioPage from "./components/Portfolio/PortfolioPage";
 import StockDetail from "./components/Dashboard/StocksDetail/StocksDetail";
+import ProfilePage from "./components/Profile/ProfilePage";
 
 import { AuthProvider } from "./context/AuthContext";
 import PrivateRoute from "./private/PrivateRoute";
@@ -50,6 +51,14 @@ function App() {
                 element={
                   <PrivateRoute>
                     <PortfolioPage />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/profile"
+                element={
+                  <PrivateRoute>
+                    <ProfilePage />
                   </PrivateRoute>
                 }
               />

--- a/technomoney-app/src/components/Header/Header.tsx
+++ b/technomoney-app/src/components/Header/Header.tsx
@@ -1,5 +1,6 @@
 import { FaBars, FaBell, FaUserCircle } from "react-icons/fa";
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import UserPopup from "../Popups/UserPopup/UserPopup";
 import HelpPopup from "../Popups/HelpPopup/HelpPopup";
 import MyAccountPopup from "../Popups/MyAccountPopup/MyAccountPopup";
@@ -14,6 +15,8 @@ const Header: React.FC = () => {
   const [showAccount, setShowAccount] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
+
+  const navigate = useNavigate();
 
   const togglePopup = () => {
     setIsPopupOpen(!isPopupOpen);
@@ -67,6 +70,10 @@ const Header: React.FC = () => {
           backToProfile={() => {
             setShowAccount(false);
             setIsPopupOpen(true);
+          }}
+          onEditProfile={() => {
+            setShowAccount(false);
+            navigate("/profile");
           }}
         />
       )}

--- a/technomoney-app/src/components/Popups/MyAccountPopup/MyAccountPopup.tsx
+++ b/technomoney-app/src/components/Popups/MyAccountPopup/MyAccountPopup.tsx
@@ -5,11 +5,13 @@ import { Button } from "../../ui/Button";
 interface MyAccountPopupProps {
   onClose: () => void;
   backToProfile: () => void;
+  onEditProfile: () => void;
 }
 
 const MyAccountPopup: React.FC<MyAccountPopupProps> = ({
   onClose,
   backToProfile,
+  onEditProfile,
 }) => {
   const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) =>
     e.target === e.currentTarget && onClose();
@@ -60,10 +62,10 @@ const MyAccountPopup: React.FC<MyAccountPopupProps> = ({
 
             <Button
               variant="primary"
-              onClick={() => alert("Editar dados – implemente")}
+              onClick={onEditProfile}
               className="custom-button"
             >
-              Editar Informações
+              Editar dados
             </Button>
           </div>
 

--- a/technomoney-app/src/components/Profile/ProfilePage.css
+++ b/technomoney-app/src/components/Profile/ProfilePage.css
@@ -1,0 +1,123 @@
+.profile-page {
+  max-width: 960px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background-color: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.1);
+  color: #0f172a;
+}
+
+.profile-page h1 {
+  font-size: 2rem;
+  margin-bottom: 0.25rem;
+}
+
+.profile-page p.description {
+  margin-bottom: 2rem;
+  color: #475569;
+}
+
+.profile-form {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.profile-section {
+  display: grid;
+  gap: 1rem;
+}
+
+.profile-section h2 {
+  font-size: 1.25rem;
+  margin: 0;
+  color: #1e293b;
+}
+
+.profile-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .profile-grid.two-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.profile-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.profile-field label {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.profile-field input,
+.profile-field textarea,
+.profile-field select {
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+  font-size: 1rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.profile-field input:focus,
+.profile-field textarea:focus,
+.profile-field select:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.profile-field textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.profile-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 1rem;
+  align-items: center;
+}
+
+.profile-status {
+  font-weight: 600;
+}
+
+.profile-status.success {
+  color: #16a34a;
+}
+
+.profile-status.error {
+  color: #dc2626;
+}
+
+.loading-state {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #475569;
+}
+
+.loading-spinner {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 3px solid rgba(99, 102, 241, 0.3);
+  border-top-color: #6366f1;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/technomoney-app/src/components/Profile/ProfilePage.tsx
+++ b/technomoney-app/src/components/Profile/ProfilePage.tsx
@@ -1,0 +1,316 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Button } from "../ui/Button";
+import "./ProfilePage.css";
+import { fetchProfile, getErrorMessage, saveProfile } from "../../services/profile";
+import type { Profile, ProfileInput } from "../../types/profile";
+
+interface FormState {
+  first_name: string;
+  last_name: string;
+  birth_date: string;
+  phone_number: string;
+  profession: string;
+  biography: string;
+  address_line1: string;
+  address_line2: string;
+  city: string;
+  state: string;
+  postal_code: string;
+  country: string;
+}
+
+const emptyState: FormState = {
+  first_name: "",
+  last_name: "",
+  birth_date: "",
+  phone_number: "",
+  profession: "",
+  biography: "",
+  address_line1: "",
+  address_line2: "",
+  city: "",
+  state: "",
+  postal_code: "",
+  country: "",
+};
+
+function toFormState(profile: Profile | null | undefined): FormState {
+  if (!profile) return { ...emptyState };
+  return {
+    first_name: profile.first_name ?? "",
+    last_name: profile.last_name ?? "",
+    birth_date: profile.birth_date ?? "",
+    phone_number: profile.phone_number ?? "",
+    profession: profile.profession ?? "",
+    biography: profile.biography ?? "",
+    address_line1: profile.address_line1 ?? "",
+    address_line2: profile.address_line2 ?? "",
+    city: profile.city ?? "",
+    state: profile.state ?? "",
+    postal_code: profile.postal_code ?? "",
+    country: profile.country ?? "",
+  };
+}
+
+function normalizePayload(state: FormState): ProfileInput {
+  return Object.entries(state).reduce<ProfileInput>((acc, [key, value]) => {
+    acc[key as keyof ProfileInput] = value.trim() === "" ? null : value;
+    return acc;
+  }, {});
+}
+
+const ProfilePage: React.FC = () => {
+  const queryClient = useQueryClient();
+  const { data: profile, isFetching } = useQuery({
+    queryKey: ["profile"],
+    queryFn: fetchProfile,
+  });
+  const [formState, setFormState] = useState<FormState>(() => toFormState(profile));
+  const [status, setStatus] = useState<
+    { type: "success" | "error"; message: string } | null
+  >(null);
+
+  useEffect(() => {
+    setFormState(toFormState(profile));
+  }, [profile]);
+
+  const mutation = useMutation({
+    mutationFn: saveProfile,
+    onSuccess: (savedProfile) => {
+      queryClient.setQueryData(["profile"], savedProfile);
+      setStatus({ type: "success", message: "Perfil atualizado com sucesso!" });
+    },
+    onError: (error) => {
+      setStatus({ type: "error", message: getErrorMessage(error) });
+    },
+  });
+
+  const handleChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = event.target;
+    setFormState((prev) => ({ ...prev, [name]: value }));
+    if (status) setStatus(null);
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    mutation.mutate(normalizePayload(formState));
+  };
+
+  const isSaving = mutation.isPending;
+  const isLoading = isFetching && !profile;
+
+  const lastUpdated = useMemo(() => {
+    if (!profile?.updated_at) return null;
+    try {
+      const date = new Date(profile.updated_at);
+      return new Intl.DateTimeFormat("pt-BR", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(date);
+    } catch {
+      return null;
+    }
+  }, [profile?.updated_at]);
+
+  return (
+    <main className="profile-page">
+      <h1>Minha Conta</h1>
+      <p className="description">
+        Gerencie as informações do seu perfil. Todos os campos são opcionais —
+        preencha apenas o que desejar compartilhar.
+      </p>
+
+      {isLoading ? (
+        <div className="loading-state">
+          <span className="loading-spinner" aria-hidden="true" />
+          <span>Carregando dados do perfil…</span>
+        </div>
+      ) : (
+        <form className="profile-form" onSubmit={handleSubmit}>
+          <section className="profile-section">
+            <h2>Informações pessoais</h2>
+            <div className="profile-grid two-columns">
+              <div className="profile-field">
+                <label htmlFor="first_name">Nome</label>
+                <input
+                  id="first_name"
+                  name="first_name"
+                  type="text"
+                  placeholder="Seu nome"
+                  value={formState.first_name}
+                  onChange={handleChange}
+                  autoComplete="given-name"
+                />
+              </div>
+              <div className="profile-field">
+                <label htmlFor="last_name">Sobrenome</label>
+                <input
+                  id="last_name"
+                  name="last_name"
+                  type="text"
+                  placeholder="Seu sobrenome"
+                  value={formState.last_name}
+                  onChange={handleChange}
+                  autoComplete="family-name"
+                />
+              </div>
+              <div className="profile-field">
+                <label htmlFor="birth_date">Data de nascimento</label>
+                <input
+                  id="birth_date"
+                  name="birth_date"
+                  type="date"
+                  value={formState.birth_date}
+                  onChange={handleChange}
+                  max={new Date().toISOString().split("T")[0]}
+                />
+              </div>
+              <div className="profile-field">
+                <label htmlFor="phone_number">Telefone</label>
+                <input
+                  id="phone_number"
+                  name="phone_number"
+                  type="tel"
+                  placeholder="(00) 00000-0000"
+                  value={formState.phone_number}
+                  onChange={handleChange}
+                  autoComplete="tel"
+                />
+              </div>
+            </div>
+          </section>
+
+          <section className="profile-section">
+            <h2>Profissão e biografia</h2>
+            <div className="profile-grid">
+              <div className="profile-field">
+                <label htmlFor="profession">Profissão</label>
+                <input
+                  id="profession"
+                  name="profession"
+                  type="text"
+                  placeholder="Ex.: Analista financeiro"
+                  value={formState.profession}
+                  onChange={handleChange}
+                  autoComplete="organization-title"
+                />
+              </div>
+              <div className="profile-field">
+                <label htmlFor="biography">Sobre você</label>
+                <textarea
+                  id="biography"
+                  name="biography"
+                  placeholder="Conte um pouco sobre você, suas metas e interesses."
+                  value={formState.biography}
+                  onChange={handleChange}
+                />
+              </div>
+            </div>
+          </section>
+
+          <section className="profile-section">
+            <h2>Endereço</h2>
+            <div className="profile-grid two-columns">
+              <div className="profile-field">
+                <label htmlFor="address_line1">Endereço</label>
+                <input
+                  id="address_line1"
+                  name="address_line1"
+                  type="text"
+                  placeholder="Rua, número"
+                  value={formState.address_line1}
+                  onChange={handleChange}
+                  autoComplete="address-line1"
+                />
+              </div>
+              <div className="profile-field">
+                <label htmlFor="address_line2">Complemento</label>
+                <input
+                  id="address_line2"
+                  name="address_line2"
+                  type="text"
+                  placeholder="Apartamento, bloco, referência"
+                  value={formState.address_line2}
+                  onChange={handleChange}
+                  autoComplete="address-line2"
+                />
+              </div>
+              <div className="profile-field">
+                <label htmlFor="city">Cidade</label>
+                <input
+                  id="city"
+                  name="city"
+                  type="text"
+                  placeholder="Sua cidade"
+                  value={formState.city}
+                  onChange={handleChange}
+                  autoComplete="address-level2"
+                />
+              </div>
+              <div className="profile-field">
+                <label htmlFor="state">Estado</label>
+                <input
+                  id="state"
+                  name="state"
+                  type="text"
+                  placeholder="UF"
+                  value={formState.state}
+                  onChange={handleChange}
+                  autoComplete="address-level1"
+                />
+              </div>
+              <div className="profile-field">
+                <label htmlFor="postal_code">CEP</label>
+                <input
+                  id="postal_code"
+                  name="postal_code"
+                  type="text"
+                  placeholder="00000-000"
+                  value={formState.postal_code}
+                  onChange={handleChange}
+                  autoComplete="postal-code"
+                />
+              </div>
+              <div className="profile-field">
+                <label htmlFor="country">País</label>
+                <input
+                  id="country"
+                  name="country"
+                  type="text"
+                  placeholder="Brasil"
+                  value={formState.country}
+                  onChange={handleChange}
+                  autoComplete="country-name"
+                />
+              </div>
+            </div>
+          </section>
+
+          <div className="profile-actions">
+            {status && (
+              <span
+                role="status"
+                className={`profile-status ${status.type}`}
+              >
+                {status.message}
+              </span>
+            )}
+            {lastUpdated && !isSaving && (
+              <span className="profile-status" aria-live="polite">
+                Última atualização: {lastUpdated}
+              </span>
+            )}
+            <Button type="submit" disabled={isSaving}>
+              {isSaving ? "Salvando..." : "Salvar alterações"}
+            </Button>
+          </div>
+        </form>
+      )}
+    </main>
+  );
+};
+
+export default ProfilePage;

--- a/technomoney-app/src/services/http.ts
+++ b/technomoney-app/src/services/http.ts
@@ -165,6 +165,9 @@ function createApi(
 }
 
 export const api = createApi(import.meta.env.VITE_API_URL as string);
+export const profileApi = createApi(
+  import.meta.env.VITE_PROFILE_API_URL as string
+);
 export const paymentsApi = createApi(
   import.meta.env.VITE_PAYMENTS_API_URL as string
 );

--- a/technomoney-app/src/services/profile.ts
+++ b/technomoney-app/src/services/profile.ts
@@ -1,0 +1,28 @@
+import type { AxiosError } from "axios";
+import { profileApi } from "./http";
+import type { Profile, ProfileInput, ProfileResponse } from "../types/profile";
+
+export async function fetchProfile(): Promise<Profile | null> {
+  const response = await profileApi.get<ProfileResponse>("/profile");
+  return response.data.profile;
+}
+
+export async function saveProfile(data: ProfileInput): Promise<Profile> {
+  const response = await profileApi.put<ProfileResponse>("/profile", data);
+  if (!response.data.profile) {
+    throw new Error("Perfil não retornado pelo servidor");
+  }
+  return response.data.profile;
+}
+
+export function getErrorMessage(error: unknown): string {
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object") {
+    const err = error as AxiosError<{ error?: string; message?: string }>;
+    const data = err.response?.data;
+    if (typeof data?.error === "string" && data.error.trim()) return data.error;
+    if (typeof data?.message === "string" && data.message.trim())
+      return data.message;
+  }
+  return "Não foi possível salvar os dados do perfil.";
+}

--- a/technomoney-app/src/types/profile.ts
+++ b/technomoney-app/src/types/profile.ts
@@ -1,0 +1,37 @@
+export interface Profile {
+  id: string;
+  user_id: string;
+  first_name: string | null;
+  last_name: string | null;
+  birth_date: string | null;
+  phone_number: string | null;
+  profession: string | null;
+  biography: string | null;
+  address_line1: string | null;
+  address_line2: string | null;
+  city: string | null;
+  state: string | null;
+  postal_code: string | null;
+  country: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type ProfileInput = {
+  first_name?: string | null;
+  last_name?: string | null;
+  birth_date?: string | null;
+  phone_number?: string | null;
+  profession?: string | null;
+  biography?: string | null;
+  address_line1?: string | null;
+  address_line2?: string | null;
+  city?: string | null;
+  state?: string | null;
+  postal_code?: string | null;
+  country?: string | null;
+};
+
+export interface ProfileResponse {
+  profile: Profile | null;
+}

--- a/technomoney-profile-api/.dockerignore
+++ b/technomoney-profile-api/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log
+yarn.lock
+pnpm-lock.yaml
+dist
+.git
+.gitignore
+Dockerfile
+.dockerignore

--- a/technomoney-profile-api/.gitignore
+++ b/technomoney-profile-api/.gitignore
@@ -1,0 +1,15 @@
+# dependencies
+/node_modules
+/package-lock.json
+
+# build output
+/dist
+
+# local env files
+.env*
+
+# misc
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store

--- a/technomoney-profile-api/.sequelizerc
+++ b/technomoney-profile-api/.sequelizerc
@@ -1,0 +1,14 @@
+const path = require("path");
+
+const baseDir = process.env.SEQUELIZE_BASE_DIR
+  ? process.env.SEQUELIZE_BASE_DIR
+  : process.env.NODE_ENV === "production"
+    ? "dist"
+    : "src";
+
+module.exports = {
+  config: path.resolve(baseDir, "config", "config.js"),
+  "models-path": path.resolve(baseDir, "models"),
+  "seeders-path": path.resolve(baseDir, "seeders"),
+  "migrations-path": path.resolve(baseDir, "migrations"),
+};

--- a/technomoney-profile-api/Dockerfile
+++ b/technomoney-profile-api/Dockerfile
@@ -1,0 +1,32 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci
+
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+COPY --from=deps /app/node_modules ./node_modules
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+RUN if [ -d "src/models" ]; then mkdir -p dist/models && cp -r src/models/. dist/models/; fi
+RUN if [ -d "src/config" ]; then mkdir -p dist/config && cp -r src/config/. dist/config/; fi
+RUN if [ -d "src/migrations" ]; then mkdir -p dist/migrations && cp -r src/migrations/. dist/migrations/; fi
+RUN if [ -f "src/openapi.yaml" ]; then mkdir -p dist && cp src/openapi.yaml dist/openapi.yaml; fi
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package*.json ./
+COPY --from=deps /app/node_modules ./node_modules
+RUN npm prune --omit=dev
+COPY --from=build /app/dist ./dist
+COPY .sequelizerc ./.sequelizerc
+COPY docker/entrypoint.sh ./entrypoint.sh
+RUN chmod 550 entrypoint.sh
+ENV HOST=0.0.0.0
+ENV PORT=4003
+ENV SWAGGER_FILE=/app/dist/openapi.yaml
+EXPOSE 4003
+ENTRYPOINT ["./entrypoint.sh"]

--- a/technomoney-profile-api/docker/entrypoint.sh
+++ b/technomoney-profile-api/docker/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -euo pipefail
+
+if [ "${SKIP_DB_MIGRATIONS:-0}" = "1" ]; then
+  echo "[profile-entrypoint] SKIP_DB_MIGRATIONS=1 detectado - pulando migrations."
+else
+  echo "[profile-entrypoint] Aplicando migrations do banco de dados..."
+  node -e "require('child_process').execSync('npx sequelize-cli db:migrate', { stdio: 'inherit' });"
+  echo "[profile-entrypoint] Migrations aplicadas com sucesso."
+fi
+
+if [ -z "${SWAGGER_FILE:-}" ] && [ -f "/app/dist/openapi.yaml" ]; then
+  export SWAGGER_FILE=/app/dist/openapi.yaml
+fi
+
+exec node "${ENTRY_FILE:-dist/server.js}"

--- a/technomoney-profile-api/nodemon.json
+++ b/technomoney-profile-api/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "watch": ["src"],
+  "ext": "ts",
+  "exec": "ts-node -r tsconfig-paths/register src/server.ts"
+}

--- a/technomoney-profile-api/package.json
+++ b/technomoney-profile-api/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "technomoney-profile-api",
+  "version": "1.0.0",
+  "description": "Technomoney profile microservice",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js",
+    "dev": "nodemon",
+    "migrate": "sequelize-cli db:migrate",
+    "migrate:undo": "sequelize-cli db:migrate:undo"
+  },
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "cookie-parser": "^1.4.7",
+    "cors": "^2.8.5",
+    "dotenv": "^16.5.0",
+    "express": "^5.1.0",
+    "helmet": "^8.1.0",
+    "pg": "^8.12.0",
+    "pg-hstore": "^2.3.4",
+    "pino": "^9.7.0",
+    "sequelize": "^6.37.7",
+    "sequelize-cli": "^6.6.3",
+    "swagger-ui-express": "^5.0.1",
+    "yamljs": "^0.3.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/cookie-parser": "^1.4.9",
+    "@types/cors": "^2.8.19",
+    "@types/express": "^5.0.1",
+    "@types/node": "^22.18.1",
+    "@types/swagger-ui-express": "^4.1.8",
+    "@types/yamljs": "^0.2.34",
+    "nodemon": "^3.1.10",
+    "pino-pretty": "^13.0.0",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.8.3"
+  }
+}

--- a/technomoney-profile-api/prod.env
+++ b/technomoney-profile-api/prod.env
@@ -1,0 +1,12 @@
+NODE_ENV=production
+PORT=4003
+DB_DRIVER=postgres
+DB_HOST=postgres
+DB_PORT=5432
+DB_USERNAME=technomoney
+DB_PASSWORD=technopass
+DB_DATABASE=technomoney_auth
+AUTH_INTROSPECTION_URL=https://auth.technomoney.local/oauth2/introspect
+AUTH_INTROSPECTION_CLIENT_ID=profile-service
+AUTH_INTROSPECTION_CLIENT_SECRET=profile-secret
+CORS_ALLOWED_ORIGINS=https://www.technomoney.net.br,https://technomoney.net.br

--- a/technomoney-profile-api/src/app.ts
+++ b/technomoney-profile-api/src/app.ts
@@ -1,0 +1,58 @@
+import express, { Application } from "express";
+import cors, { CorsOptions } from "cors";
+import cookieParser from "cookie-parser";
+import swaggerUi from "swagger-ui-express";
+import profileRoutes from "./routes/profileRoutes";
+import { swaggerSpec } from "./swagger";
+import { errorHandler } from "./middlewares/error.middleware";
+import { secureHeaders, forceHttps } from "./middlewares/secureHeaders.middleware";
+
+const defaultOrigins = [
+  "https://www.technomoney.net.br",
+  "https://technomoney.net.br",
+  "http://localhost:5173",
+  "http://localhost:3000",
+  "http://localhost:4003",
+  "http://localhost",
+  "https://localhost",
+];
+
+function buildCorsOrigins(): string[] {
+  const extra = process.env.CORS_ALLOWED_ORIGINS || "";
+  const parsed = extra
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+  return Array.from(new Set([...defaultOrigins, ...parsed]));
+}
+
+export function createApp(): Application {
+  const app = express();
+
+  app.set("trust proxy", 1);
+
+  const allowedOrigins = buildCorsOrigins();
+
+  const corsOptions: CorsOptions = {
+    origin: (origin, cb) => {
+      if (!origin) return cb(null, true);
+      if (allowedOrigins.includes(origin)) return cb(null, true);
+      cb(new Error("Origin not allowed"));
+    },
+    credentials: true,
+  };
+
+  app.use(secureHeaders);
+  app.use(forceHttps);
+  app.use(cors(corsOptions));
+  app.use(cookieParser());
+  app.use(express.json());
+  app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+  app.use("/api", profileRoutes);
+  app.use((_req, res) => {
+    res.status(404).json({ message: "Rota não encontrada." });
+  });
+  app.use(errorHandler);
+
+  return app;
+}

--- a/technomoney-profile-api/src/config/config.js
+++ b/technomoney-profile-api/src/config/config.js
@@ -1,0 +1,33 @@
+const fs = require("fs");
+const path = require("path");
+require("dotenv").config();
+
+let exported;
+
+try {
+  require("ts-node").register({
+    transpileOnly: true,
+    compilerOptions: { module: "CommonJS" },
+    project: path.resolve(__dirname, "..", "..", "tsconfig.json"),
+  });
+  const cfg = require("./config.ts");
+  exported = cfg.default || cfg;
+} catch (err) {
+  const distPath = path.resolve(__dirname, "..", "..", "dist", "config", "config.js");
+  if (!fs.existsSync(distPath)) {
+    throw err;
+  }
+  const compiled = require(distPath);
+  exported = compiled.default || compiled;
+}
+
+console.log(
+  "[profile-db config] env=%s host=%s user=%s pwdType=%s pwdLen=%d",
+  process.env.NODE_ENV || "development",
+  process.env.DB_HOST,
+  process.env.DB_USERNAME,
+  typeof process.env.DB_PASSWORD,
+  (process.env.DB_PASSWORD || "").length
+);
+
+module.exports = exported;

--- a/technomoney-profile-api/src/config/config.ts
+++ b/technomoney-profile-api/src/config/config.ts
@@ -1,0 +1,39 @@
+import "dotenv/config";
+import { Options } from "sequelize";
+
+type DbEnv = "production" | "development" | "test";
+type DbOptions = Options & {
+  use_env_variable?: string;
+  username?: string;
+  password?: string;
+  database?: string;
+  host?: string;
+  port?: number;
+};
+
+const S = (v: unknown, fallback = ""): string =>
+  v === undefined || v === null ? fallback : String(v);
+
+const N = (v: unknown, fallback = 0): number => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+};
+
+const base: DbOptions = {
+  username: S(process.env.DB_USERNAME, "postgres"),
+  password: S(process.env.DB_PASSWORD, ""),
+  database: S(process.env.DB_DATABASE, "technomoney_auth"),
+  host: S(process.env.DB_HOST, "127.0.0.1"),
+  port: N(process.env.DB_PORT, 5432),
+  dialect: (process.env.DB_DRIVER || "postgres") as any,
+  logging: false,
+  dialectOptions: { ssl: false },
+};
+
+const config: Record<DbEnv, DbOptions> = {
+  production: { ...base },
+  development: { ...base },
+  test: { ...base },
+};
+
+export = config;

--- a/technomoney-profile-api/src/config/env.ts
+++ b/technomoney-profile-api/src/config/env.ts
@@ -1,0 +1,22 @@
+import "dotenv/config";
+import { z } from "zod";
+
+const EnvSchema = z.object({
+  NODE_ENV: z
+    .enum(["development", "test", "production"])
+    .default("development"),
+  PORT: z.string().optional(),
+  DB_HOST: z.string(),
+  DB_USERNAME: z.string(),
+  DB_PASSWORD: z.string().optional().default(""),
+  DB_DATABASE: z.string(),
+  DB_DRIVER: z.string().default("postgres"),
+  DB_PORT: z.string().optional(),
+  AUTH_INTROSPECTION_URL: z.string().url(),
+  AUTH_INTROSPECTION_CLIENT_ID: z.string(),
+  AUTH_INTROSPECTION_CLIENT_SECRET: z.string(),
+  CORS_ALLOWED_ORIGINS: z.string().optional(),
+  LOG_LEVEL: z.enum(["debug", "info", "warn", "error"]).optional(),
+});
+
+export const env = EnvSchema.parse(process.env);

--- a/technomoney-profile-api/src/controllers/profile.controller.ts
+++ b/technomoney-profile-api/src/controllers/profile.controller.ts
@@ -1,0 +1,29 @@
+import { Request, Response } from "express";
+import { asyncHandler } from "../middlewares/asyncHandler.middleware";
+import { ProfileService } from "../services/profile.service";
+
+const service = new ProfileService();
+
+export const getMyProfile = asyncHandler(async (req: Request, res: Response) => {
+  const userId = (req as any).user?.id as string | undefined;
+  if (!userId) {
+    res.status(401).json({ message: "Unauthorized" });
+    return;
+  }
+
+  const profile = await service.getByUserId(userId);
+  res.json({ profile });
+});
+
+export const upsertMyProfile = asyncHandler(
+  async (req: Request, res: Response) => {
+    const userId = (req as any).user?.id as string | undefined;
+    if (!userId) {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    const profile = await service.upsert(userId, req.body || {});
+    res.status(200).json({ profile });
+  }
+);

--- a/technomoney-profile-api/src/middlewares/asyncHandler.middleware.ts
+++ b/technomoney-profile-api/src/middlewares/asyncHandler.middleware.ts
@@ -1,0 +1,7 @@
+import { Request, Response, NextFunction } from "express";
+
+export const asyncHandler =
+  (fn: (req: Request, res: Response, next: NextFunction) => Promise<unknown>) =>
+  (req: Request, res: Response, next: NextFunction) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };

--- a/technomoney-profile-api/src/middlewares/auth.middleware.ts
+++ b/technomoney-profile-api/src/middlewares/auth.middleware.ts
@@ -1,0 +1,87 @@
+import type { NextFunction, Request, Response } from "express";
+import { JwtVerifierService } from "../services/jwt-verifier.service";
+import { logger } from "../utils/logger";
+
+const verifier = new JwtVerifierService();
+
+const normalizeScope = (scope: string[] | string | undefined | null): string[] => {
+  if (Array.isArray(scope)) return scope;
+  return String(scope || "")
+    .split(" ")
+    .map((s) => s.trim())
+    .filter(Boolean);
+};
+
+const maskToken = (token: string) =>
+  !token ? "" : token.length <= 10 ? "***" : `${token.slice(0, 4)}...${token.slice(-4)}`;
+
+export const authenticate = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  let tokenForLog = "";
+  try {
+    const h = String(req.headers.authorization || "");
+    const token = h.startsWith("Bearer ")
+      ? h.slice(7)
+      : h.startsWith("DPoP ")
+      ? h.slice(5)
+      : "";
+    if (!token) {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    tokenForLog = token;
+    const introspection = await verifier.verifyAccess(token);
+
+    if (!introspection.active) {
+      res.setHeader(
+        "WWW-Authenticate",
+        'Bearer realm="api", error="invalid_token", error_description="Token is inactive"'
+      );
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    const scopeList = normalizeScope(introspection.scope);
+    const acr =
+      typeof introspection.acr === "string" ? introspection.acr : undefined;
+
+    if (acr === "step-up" || scopeList.includes("auth:stepup")) {
+      res.setHeader(
+        "WWW-Authenticate",
+        'Bearer realm="api", error="insufficient_aal", error_description="Step-up token not allowed"'
+      );
+      res.status(401).json({ message: "Step-up token requires MFA" });
+      return;
+    }
+
+    const username =
+      typeof introspection.username === "string"
+        ? introspection.username
+        : typeof introspection.preferred_username === "string"
+        ? introspection.preferred_username
+        : undefined;
+
+    (req as any).user = {
+      id: typeof introspection.sub === "string" ? introspection.sub : "",
+      jti: typeof introspection.jti === "string" ? introspection.jti : "",
+      token,
+      scope: scopeList,
+      payload: introspection,
+      acr,
+      username,
+      exp: typeof introspection.exp === "number" ? introspection.exp : undefined,
+    };
+    next();
+  } catch (e: any) {
+    logger.debug({ err: String(e), token: maskToken(tokenForLog) }, "auth.middleware.denied");
+    res.setHeader(
+      "WWW-Authenticate",
+      'Bearer realm="api", error="invalid_token", error_description="Missing or invalid token"'
+    );
+    res.status(401).json({ message: "Unauthorized" });
+  }
+};

--- a/technomoney-profile-api/src/middlewares/error.middleware.ts
+++ b/technomoney-profile-api/src/middlewares/error.middleware.ts
@@ -1,0 +1,18 @@
+import { Request, Response, NextFunction } from "express";
+import { logger } from "../utils/logger";
+import { AppError } from "../utils/app-error";
+
+export function errorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+) {
+  if (err instanceof AppError) {
+    logger.warn({ err }, "Handled error");
+    return res.status(err.status).json({ error: err.message });
+  }
+
+  logger.error({ err }, "Unhandled error");
+  res.status(500).json({ error: "Internal server error" });
+}

--- a/technomoney-profile-api/src/middlewares/scope.middleware.ts
+++ b/technomoney-profile-api/src/middlewares/scope.middleware.ts
@@ -1,0 +1,25 @@
+import { logger } from "../utils/logger";
+
+const parseScopes = (s: string) =>
+  s
+    .split(" ")
+    .map((x) => x.trim())
+    .filter(Boolean);
+
+export const requireScopes = (...need: string[]) => {
+  return (req: any, res: any, next: any) => {
+    const haveStr = String(req.user?.scope || "");
+    const have = new Set(parseScopes(haveStr));
+    const ok = need.every((n) => have.has(n));
+    if (!ok) {
+      logger.debug({ need, have: Array.from(have) }, "auth.scope.denied");
+      res.setHeader(
+        "WWW-Authenticate",
+        `Bearer realm="api", error="insufficient_scope", scope="${need.join(" ")}"`
+      );
+      res.status(403).json({ message: "Forbidden" });
+      return;
+    }
+    next();
+  };
+};

--- a/technomoney-profile-api/src/middlewares/secureHeaders.middleware.ts
+++ b/technomoney-profile-api/src/middlewares/secureHeaders.middleware.ts
@@ -1,0 +1,33 @@
+import helmet from "helmet";
+import { Request, Response, NextFunction } from "express";
+import { logger } from "../utils/logger";
+
+const cspDirectives = {
+  defaultSrc: ["'self'"],
+  scriptSrc: ["'self'"],
+  objectSrc: ["'none'"],
+  baseUri: ["'none'"],
+};
+
+export const secureHeaders = helmet({
+  contentSecurityPolicy: { directives: cspDirectives },
+  referrerPolicy: { policy: "no-referrer" },
+  frameguard: { action: "deny" },
+  hsts: { maxAge: 15552000, includeSubDomains: true, preload: true },
+  xssFilter: true,
+  noSniff: true,
+});
+
+export const forceHttps = (req: Request, res: Response, next: NextFunction) => {
+  const host = (req.headers.host || "").toLowerCase();
+  if (host.startsWith("localhost") || host.startsWith("127.0.0.1")) {
+    logger.debug({ host, path: req.originalUrl }, "https.skip_local");
+    return next();
+  }
+  if (req.secure) {
+    logger.debug({ host, path: req.originalUrl }, "https.already_secure");
+    return next();
+  }
+  logger.info({ host, path: req.originalUrl }, "https.redirect");
+  return res.redirect(301, `https://${req.headers.host}${req.originalUrl}`);
+};

--- a/technomoney-profile-api/src/migrationRunner.js
+++ b/technomoney-profile-api/src/migrationRunner.js
@@ -1,0 +1,37 @@
+const { exec } = require("child_process");
+const path = require("path");
+require("dotenv").config({ path: path.resolve(__dirname, "..", ".env") });
+
+console.log("Rodando migrations do profile-api...");
+
+exec(
+  "npx sequelize-cli db:migrate",
+  {
+    cwd: path.resolve(__dirname, ".."),
+    env: process.env,
+    windowsHide: true,
+  },
+  (error, stdout, stderr) => {
+    if (error) {
+      console.error(`Erro ao rodar migrations: ${error.message}`);
+      if (stderr) console.error(stderr);
+      process.exit(1);
+    }
+    if (stderr) console.error(`stderr: ${stderr}`);
+    console.log(stdout);
+
+    console.log("Migrations concluídas. Iniciando servidor com nodemon...");
+
+    const nodemon = exec("nodemon", {
+      cwd: path.resolve(__dirname, ".."),
+      env: process.env,
+      windowsHide: true,
+    });
+
+    nodemon.stdout.on("data", (data) => process.stdout.write(data));
+    nodemon.stderr.on("data", (data) => process.stderr.write(data));
+    nodemon.on("close", (code) =>
+      console.log(`Servidor finalizado com código ${code}`)
+    );
+  }
+);

--- a/technomoney-profile-api/src/migrations/20250301000000-create-profile.js
+++ b/technomoney-profile-api/src/migrations/20250301000000-create-profile.js
@@ -1,0 +1,87 @@
+"use strict";
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("profiles", {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal("gen_random_uuid()"),
+        allowNull: false,
+        primaryKey: true,
+      },
+      user_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        unique: true,
+        references: {
+          model: "users",
+          key: "id",
+        },
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE",
+      },
+      first_name: {
+        type: Sequelize.STRING(120),
+        allowNull: true,
+      },
+      last_name: {
+        type: Sequelize.STRING(120),
+        allowNull: true,
+      },
+      birth_date: {
+        type: Sequelize.DATEONLY,
+        allowNull: true,
+      },
+      phone_number: {
+        type: Sequelize.STRING(30),
+        allowNull: true,
+      },
+      profession: {
+        type: Sequelize.STRING(150),
+        allowNull: true,
+      },
+      biography: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      address_line1: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+      },
+      address_line2: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+      },
+      city: {
+        type: Sequelize.STRING(120),
+        allowNull: true,
+      },
+      state: {
+        type: Sequelize.STRING(120),
+        allowNull: true,
+      },
+      postal_code: {
+        type: Sequelize.STRING(30),
+        allowNull: true,
+      },
+      country: {
+        type: Sequelize.STRING(120),
+        allowNull: true,
+      },
+      created_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
+      },
+      updated_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
+      },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable("profiles");
+  },
+};

--- a/technomoney-profile-api/src/models/index.ts
+++ b/technomoney-profile-api/src/models/index.ts
@@ -1,0 +1,21 @@
+import { Sequelize as SequelizeCtor } from "sequelize";
+import { env } from "../config/env";
+import { initProfileModel, Profile } from "./profile.model";
+
+const port = env.DB_PORT ? Number(env.DB_PORT) : 5432;
+
+export const sequelize = new SequelizeCtor(
+  env.DB_DATABASE,
+  env.DB_USERNAME,
+  env.DB_PASSWORD || "",
+  {
+    host: env.DB_HOST,
+    port,
+    dialect: env.DB_DRIVER as any,
+    logging: false,
+  }
+);
+
+initProfileModel(sequelize);
+
+export { Profile };

--- a/technomoney-profile-api/src/models/profile.model.ts
+++ b/technomoney-profile-api/src/models/profile.model.ts
@@ -1,0 +1,150 @@
+import {
+  DataTypes,
+  Model,
+  Optional,
+  Sequelize,
+} from "sequelize";
+
+export interface ProfileAttributes {
+  id: string;
+  user_id: string;
+  first_name: string | null;
+  last_name: string | null;
+  birth_date: Date | null;
+  phone_number: string | null;
+  profession: string | null;
+  biography: string | null;
+  address_line1: string | null;
+  address_line2: string | null;
+  city: string | null;
+  state: string | null;
+  postal_code: string | null;
+  country: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export type ProfileCreationAttributes = Optional<
+  ProfileAttributes,
+  | "id"
+  | "first_name"
+  | "last_name"
+  | "birth_date"
+  | "phone_number"
+  | "profession"
+  | "biography"
+  | "address_line1"
+  | "address_line2"
+  | "city"
+  | "state"
+  | "postal_code"
+  | "country"
+  | "created_at"
+  | "updated_at"
+>;
+
+export class Profile
+  extends Model<ProfileAttributes, ProfileCreationAttributes>
+  implements ProfileAttributes
+{
+  declare id: string;
+  declare user_id: string;
+  declare first_name: string | null;
+  declare last_name: string | null;
+  declare birth_date: Date | null;
+  declare phone_number: string | null;
+  declare profession: string | null;
+  declare biography: string | null;
+  declare address_line1: string | null;
+  declare address_line2: string | null;
+  declare city: string | null;
+  declare state: string | null;
+  declare postal_code: string | null;
+  declare country: string | null;
+  declare created_at: Date;
+  declare updated_at: Date;
+}
+
+export function initProfileModel(sequelize: Sequelize): typeof Profile {
+  Profile.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+        allowNull: false,
+      },
+      user_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        unique: true,
+      },
+      first_name: {
+        type: DataTypes.STRING(120),
+        allowNull: true,
+      },
+      last_name: {
+        type: DataTypes.STRING(120),
+        allowNull: true,
+      },
+      birth_date: {
+        type: DataTypes.DATEONLY,
+        allowNull: true,
+      },
+      phone_number: {
+        type: DataTypes.STRING(30),
+        allowNull: true,
+      },
+      profession: {
+        type: DataTypes.STRING(150),
+        allowNull: true,
+      },
+      biography: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      address_line1: {
+        type: DataTypes.STRING(255),
+        allowNull: true,
+      },
+      address_line2: {
+        type: DataTypes.STRING(255),
+        allowNull: true,
+      },
+      city: {
+        type: DataTypes.STRING(120),
+        allowNull: true,
+      },
+      state: {
+        type: DataTypes.STRING(120),
+        allowNull: true,
+      },
+      postal_code: {
+        type: DataTypes.STRING(30),
+        allowNull: true,
+      },
+      country: {
+        type: DataTypes.STRING(120),
+        allowNull: true,
+      },
+      created_at: {
+        allowNull: false,
+        type: DataTypes.DATE,
+        defaultValue: sequelize.literal("CURRENT_TIMESTAMP"),
+      },
+      updated_at: {
+        allowNull: false,
+        type: DataTypes.DATE,
+        defaultValue: sequelize.literal("CURRENT_TIMESTAMP"),
+      },
+    },
+    {
+      sequelize,
+      tableName: "profiles",
+      modelName: "Profile",
+      timestamps: false,
+    }
+  );
+
+  return Profile;
+}

--- a/technomoney-profile-api/src/openapi.yaml
+++ b/technomoney-profile-api/src/openapi.yaml
@@ -1,0 +1,153 @@
+openapi: 3.0.3
+info:
+  title: Technomoney Profile API
+  version: 1.0.0
+servers:
+  - url: http://localhost:4003/api
+paths:
+  /profile:
+    get:
+      summary: Obtém o perfil do usuário autenticado
+      tags: [Profile]
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Perfil encontrado (ou vazio)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  profile:
+                    $ref: '#/components/schemas/Profile'
+                required: [profile]
+        '401':
+          description: Não autenticado
+    put:
+      summary: Cria ou atualiza o perfil do usuário autenticado
+      tags: [Profile]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProfileInput'
+      responses:
+        '200':
+          description: Perfil salvo
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  profile:
+                    $ref: '#/components/schemas/Profile'
+                required: [profile]
+        '400':
+          description: Dados inválidos
+        '401':
+          description: Não autenticado
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    Profile:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: string
+          format: uuid
+        user_id:
+          type: string
+          format: uuid
+        first_name:
+          type: string
+          nullable: true
+        last_name:
+          type: string
+          nullable: true
+        birth_date:
+          type: string
+          format: date
+          nullable: true
+        phone_number:
+          type: string
+          nullable: true
+        profession:
+          type: string
+          nullable: true
+        biography:
+          type: string
+          nullable: true
+        address_line1:
+          type: string
+          nullable: true
+        address_line2:
+          type: string
+          nullable: true
+        city:
+          type: string
+          nullable: true
+        state:
+          type: string
+          nullable: true
+        postal_code:
+          type: string
+          nullable: true
+        country:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    ProfileInput:
+      type: object
+      properties:
+        first_name:
+          type: string
+          nullable: true
+        last_name:
+          type: string
+          nullable: true
+        birth_date:
+          type: string
+          format: date
+          nullable: true
+        phone_number:
+          type: string
+          nullable: true
+        profession:
+          type: string
+          nullable: true
+        biography:
+          type: string
+          nullable: true
+        address_line1:
+          type: string
+          nullable: true
+        address_line2:
+          type: string
+          nullable: true
+        city:
+          type: string
+          nullable: true
+        state:
+          type: string
+          nullable: true
+        postal_code:
+          type: string
+          nullable: true
+        country:
+          type: string
+          nullable: true
+      additionalProperties: false

--- a/technomoney-profile-api/src/repositories/profile.repository.ts
+++ b/technomoney-profile-api/src/repositories/profile.repository.ts
@@ -1,0 +1,55 @@
+import {
+  Profile,
+  ProfileAttributes,
+  ProfileCreationAttributes,
+} from "../models/profile.model";
+
+export type ProfileUpsertData = Partial<
+  Pick<
+    ProfileAttributes,
+    | "first_name"
+    | "last_name"
+    | "birth_date"
+    | "phone_number"
+    | "profession"
+    | "biography"
+    | "address_line1"
+    | "address_line2"
+    | "city"
+    | "state"
+    | "postal_code"
+    | "country"
+  >
+>;
+
+export class ProfileRepository {
+  async findByUserId(userId: string): Promise<Profile | null> {
+    return Profile.findOne({ where: { user_id: userId } });
+  }
+
+  async create(userId: string, data: ProfileUpsertData): Promise<Profile> {
+    return Profile.create({
+      user_id: userId,
+      ...data,
+      updated_at: new Date(),
+    } as ProfileCreationAttributes);
+  }
+
+  async update(
+    profile: Profile,
+    data: ProfileUpsertData
+  ): Promise<Profile> {
+    return profile.update({
+      ...data,
+      updated_at: new Date(),
+    } as Partial<ProfileAttributes>);
+  }
+
+  async upsert(userId: string, data: ProfileUpsertData): Promise<Profile> {
+    const existing = await this.findByUserId(userId);
+    if (existing) {
+      return this.update(existing, data);
+    }
+    return this.create(userId, data);
+  }
+}

--- a/technomoney-profile-api/src/routes/profileRoutes.ts
+++ b/technomoney-profile-api/src/routes/profileRoutes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { authenticate } from "../middlewares/auth.middleware";
+import { requireScopes } from "../middlewares/scope.middleware";
+import { getMyProfile, upsertMyProfile } from "../controllers/profile.controller";
+
+const router = Router();
+
+router.use(authenticate);
+router.get("/profile", requireScopes("profile:read"), getMyProfile);
+router.put("/profile", requireScopes("profile:write"), upsertMyProfile);
+router.patch("/profile", requireScopes("profile:write"), upsertMyProfile);
+
+export default router;

--- a/technomoney-profile-api/src/server.ts
+++ b/technomoney-profile-api/src/server.ts
@@ -1,0 +1,39 @@
+import "./config/env";
+import { createApp } from "./app";
+import { logger } from "./utils/logger";
+
+const PORT = Number(process.env.PORT) || 4003;
+const app = createApp();
+
+const server = app.listen(PORT, () => {
+  logger.info(`Profile API running on http://localhost:${PORT}`);
+  logger.info(`Swagger UI disponível em http://localhost:${PORT}/api-docs`);
+});
+
+function toErrorString(input: unknown): string {
+  if (input instanceof Error) return input.stack ?? input.message;
+  try {
+    return typeof input === "string" ? input : JSON.stringify(input);
+  } catch {
+    return String(input);
+  }
+}
+
+function shutdown(signal: NodeJS.Signals) {
+  logger.info(`\n${signal} recebido — encerrando HTTP…`);
+  server.close(() => {
+    logger.info("HTTP encerrado com sucesso. Até logo!");
+    process.exit(0);
+  });
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+process.on("unhandledRejection", (reason) => {
+  logger.error(`Unhandled Rejection: ${toErrorString(reason)}`);
+});
+process.on("uncaughtException", (err) => {
+  logger.error(`Uncaught Exception: ${toErrorString(err)}`);
+  process.exit(1);
+});

--- a/technomoney-profile-api/src/services/jwt-verifier.service.ts
+++ b/technomoney-profile-api/src/services/jwt-verifier.service.ts
@@ -1,0 +1,53 @@
+export type IntrospectionSuccess = {
+  active: boolean;
+  sub?: string;
+  scope?: string | string[];
+  username?: string;
+  preferred_username?: string;
+  jti?: string;
+  acr?: string;
+  exp?: number;
+  [key: string]: unknown;
+};
+
+type FetchLike = typeof fetch;
+
+export class JwtVerifierService {
+  constructor(private readonly fetchFn: FetchLike = fetch) {}
+
+  async verifyAccess(token: string): Promise<IntrospectionSuccess> {
+    const url = process.env.AUTH_INTROSPECTION_URL;
+    if (!url) {
+      throw new Error("AUTH_INTROSPECTION_URL is not configured");
+    }
+
+    const clientId = process.env.AUTH_INTROSPECTION_CLIENT_ID || "";
+    const clientSecret = process.env.AUTH_INTROSPECTION_CLIENT_SECRET || "";
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/x-www-form-urlencoded",
+    };
+
+    if (clientId && clientSecret) {
+      const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+      headers.Authorization = `Basic ${basic}`;
+    }
+
+    const body = new URLSearchParams({
+      token,
+      token_type_hint: "access_token",
+    });
+
+    const res = await this.fetchFn(url, {
+      method: "POST",
+      headers,
+      body,
+    });
+
+    if (!res.ok) {
+      throw new Error(`introspection request failed with status ${res.status}`);
+    }
+
+    return (await res.json()) as IntrospectionSuccess;
+  }
+}

--- a/technomoney-profile-api/src/services/profile.service.ts
+++ b/technomoney-profile-api/src/services/profile.service.ts
@@ -1,0 +1,123 @@
+import { AppError } from "../utils/app-error";
+import { Profile } from "../models/profile.model";
+import {
+  ProfileRepository,
+  ProfileUpsertData,
+} from "../repositories/profile.repository";
+
+export interface ProfileInput {
+  first_name?: string | null;
+  last_name?: string | null;
+  birth_date?: string | null;
+  phone_number?: string | null;
+  profession?: string | null;
+  biography?: string | null;
+  address_line1?: string | null;
+  address_line2?: string | null;
+  city?: string | null;
+  state?: string | null;
+  postal_code?: string | null;
+  country?: string | null;
+}
+
+export interface ProfileDto {
+  id: string;
+  user_id: string;
+  first_name: string | null;
+  last_name: string | null;
+  birth_date: string | null;
+  phone_number: string | null;
+  profession: string | null;
+  biography: string | null;
+  address_line1: string | null;
+  address_line2: string | null;
+  city: string | null;
+  state: string | null;
+  postal_code: string | null;
+  country: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function toDto(profile: Profile): ProfileDto {
+  const toDateString = (value: Date | null) =>
+    value ? value.toISOString().split("T")[0] : null;
+  return {
+    id: profile.id,
+    user_id: profile.user_id,
+    first_name: profile.first_name,
+    last_name: profile.last_name,
+    birth_date: toDateString(profile.birth_date),
+    phone_number: profile.phone_number,
+    profession: profile.profession,
+    biography: profile.biography,
+    address_line1: profile.address_line1,
+    address_line2: profile.address_line2,
+    city: profile.city,
+    state: profile.state,
+    postal_code: profile.postal_code,
+    country: profile.country,
+    created_at: profile.created_at.toISOString(),
+    updated_at: profile.updated_at.toISOString(),
+  };
+}
+
+const normalizeString = (value?: string | null) => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+};
+
+export class ProfileService {
+  constructor(private readonly repo = new ProfileRepository()) {}
+
+  async getByUserId(userId: string): Promise<ProfileDto | null> {
+    const profile = await this.repo.findByUserId(userId);
+    return profile ? toDto(profile) : null;
+  }
+
+  async upsert(userId: string, payload: ProfileInput): Promise<ProfileDto> {
+    if (!userId) {
+      throw new AppError(400, "Usuário inválido");
+    }
+
+    const data: ProfileUpsertData = {};
+
+    const normalizedBirth = normalizeString(payload.birth_date);
+    if (payload.birth_date !== undefined) {
+      if (normalizedBirth === null) {
+        data.birth_date = null;
+      } else if (normalizedBirth) {
+        const parsed = new Date(normalizedBirth);
+        if (Number.isNaN(parsed.getTime())) {
+          throw new AppError(400, "Data de nascimento inválida");
+        }
+        data.birth_date = parsed;
+      }
+    }
+
+    const mapFields: (keyof ProfileInput)[] = [
+      "first_name",
+      "last_name",
+      "phone_number",
+      "profession",
+      "biography",
+      "address_line1",
+      "address_line2",
+      "city",
+      "state",
+      "postal_code",
+      "country",
+    ];
+
+    for (const field of mapFields) {
+      if (field in payload) {
+        (data as any)[field] = normalizeString(payload[field]);
+      }
+    }
+
+    const profile = await this.repo.upsert(userId, data);
+    return toDto(profile);
+  }
+}

--- a/technomoney-profile-api/src/swagger.ts
+++ b/technomoney-profile-api/src/swagger.ts
@@ -1,0 +1,28 @@
+import fs from "fs";
+import path from "path";
+import YAML from "yamljs";
+
+const candidates = [
+  process.env.SWAGGER_FILE,
+  path.resolve(__dirname, "openapi.yaml"),
+  path.resolve(__dirname, "..", "openapi.yaml"),
+  path.resolve(process.cwd(), "openapi.yaml"),
+].filter(Boolean) as string[];
+
+const swaggerPath =
+  candidates.find((p) => {
+    try {
+      return fs.statSync(p).isFile();
+    } catch {
+      return false;
+    }
+  }) || null;
+
+if (!swaggerPath) {
+  throw new Error(
+    `openapi.yaml não encontrado. Defina SWAGGER_FILE ou coloque o arquivo em dist/ ou na raiz.\n` +
+      `Procurado em:\n- ${candidates.join("\n- ")}`
+  );
+}
+
+export const swaggerSpec = YAML.load(swaggerPath);

--- a/technomoney-profile-api/src/utils/app-error.ts
+++ b/technomoney-profile-api/src/utils/app-error.ts
@@ -1,0 +1,6 @@
+export class AppError extends Error {
+  constructor(public readonly status: number, message: string) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/technomoney-profile-api/src/utils/logger.ts
+++ b/technomoney-profile-api/src/utils/logger.ts
@@ -1,0 +1,18 @@
+import pino from "pino";
+
+const isProd = process.env.NODE_ENV === "production";
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL ?? (isProd ? "info" : "debug"),
+  transport: isProd
+    ? undefined
+    : {
+        target: "pino-pretty",
+        options: {
+          colorize: true,
+          translateTime: "HH:MM:ss",
+          ignore: "pid,hostname",
+        },
+      },
+  timestamp: pino.stdTimeFunctions.isoTime,
+});

--- a/technomoney-profile-api/tsconfig.json
+++ b/technomoney-profile-api/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@technomoney/types/*": ["../types/*"]
+    }
+  },
+  "include": ["src", "src/types/**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary
- add the technomoney-profile-api service with Sequelize models, migrations, authenticated routes, and OpenAPI docs for managing user profiles
- register the profile container in docker-compose and allow it to introspect tokens through the auth service
- connect the frontend to the new profile API with a protected /profile route, query/mutation hooks, and updated navigation

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69128788a3b883279e41e951fa4749c9)