### PR TITLE
Add monthly access report

### DIFF
--- a/technomoney-api/Dockerfile
+++ b/technomoney-api/Dockerfile
@@ -25,7 +25,7 @@ RUN npm prune --omit=dev
 COPY --from=build /app/dist ./dist
 COPY .sequelizerc ./.sequelizerc
 COPY docker/entrypoint.sh ./entrypoint.sh
-RUN chmod 550 entrypoint.sh
+RUN sed -i 's/\r$//' entrypoint.sh && chmod 550 entrypoint.sh
 ENV HOST=0.0.0.0
 ENV PORT=4002
 ENV SWAGGER_FILE=/app/dist/openapi.yaml

--- a/technomoney-app/src/App.tsx
+++ b/technomoney-app/src/App.tsx
@@ -11,6 +11,7 @@ import Register from "./components/Login/Register";
 import Dashboard from "./components/Dashboard/Dashboard";
 import PortfolioPage from "./components/Portfolio/PortfolioPage";
 import StockDetail from "./components/Dashboard/StocksDetail/StocksDetail";
+import AccessReport from "./components/AccessReport/AccessReport";
 
 import { AuthProvider } from "./context/AuthContext";
 import PrivateRoute from "./private/PrivateRoute";
@@ -60,6 +61,14 @@ function App() {
                 element={
                   <PrivateRoute>
                     <StockDetail />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/access-report"
+                element={
+                  <PrivateRoute>
+                    <AccessReport />
                   </PrivateRoute>
                 }
               />

--- a/technomoney-app/src/components/AccessReport/AccessReport.css
+++ b/technomoney-app/src/components/AccessReport/AccessReport.css
@@ -1,0 +1,187 @@
+.access-report {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 20px 48px;
+  color: #1b1b1b;
+}
+
+.access-report__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-end;
+}
+
+.access-report__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-size: 12px;
+  color: #6b7280;
+  margin: 0 0 4px;
+}
+
+.access-report h1 {
+  margin: 0;
+  font-size: 28px;
+}
+
+.access-report__subtitle {
+  margin: 6px 0 0;
+  color: #4b5563;
+  max-width: 720px;
+}
+
+.access-report__month-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.access-report__month-picker input {
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  min-width: 180px;
+  font-size: 14px;
+}
+
+.access-report__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.access-report__card {
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.03);
+  position: relative;
+}
+
+.access-report__card--info {
+  background: linear-gradient(135deg, #f7faff, #eef2ff);
+}
+
+.access-report__card-label {
+  margin: 0;
+  color: #6b7280;
+  font-size: 13px;
+}
+
+.access-report__card-value {
+  display: block;
+  font-size: 26px;
+  margin-top: 4px;
+  color: #111827;
+}
+
+.access-report__card-value--muted {
+  font-size: 16px;
+  color: #1f2937;
+  font-weight: 600;
+}
+
+.access-report__card-help {
+  margin: 6px 0 0;
+  color: #6b7280;
+  font-size: 13px;
+}
+
+.access-report__chip {
+  display: inline-block;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #1d4ed8;
+  color: white;
+  font-size: 12px;
+  margin-top: 10px;
+}
+
+.access-report__table {
+  margin-top: 28px;
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+}
+
+.access-report__table-header {
+  padding: 16px 20px 8px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.access-report__table-header h2 {
+  margin: 0 0 4px;
+}
+
+.access-report__table-header p {
+  margin: 0;
+  color: #6b7280;
+}
+
+.access-report__table-wrapper {
+  overflow-x: auto;
+}
+
+.access-report table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.access-report th,
+.access-report td {
+  text-align: left;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.access-report th {
+  background: #f9fafb;
+  color: #4b5563;
+  font-weight: 600;
+}
+
+.access-report__revoked {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.access-report__loading,
+.access-report__error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 24px;
+}
+
+.access-report__error p {
+  margin: 0;
+}
+
+.access-report__empty {
+  padding: 16px 20px;
+  color: #6b7280;
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .access-report__header {
+    align-items: flex-start;
+  }
+
+  .access-report__month-picker {
+    width: 100%;
+  }
+
+  .access-report__month-picker input {
+    width: 100%;
+  }
+}

--- a/technomoney-app/src/components/AccessReport/AccessReport.css
+++ b/technomoney-app/src/components/AccessReport/AccessReport.css
@@ -1,12 +1,22 @@
-.access-report {
+.access-report-page {
   width: 100%;
-  max-width: 1180px;
+  min-height: calc(100vh - 40px);
+  display: flex;
+  justify-content: center;
+  padding: 80px 20px 48px;
+  background: radial-gradient(circle at 20% 20%, rgba(12, 179, 168, 0.08), transparent 35%),
+    radial-gradient(circle at 80% 0%, rgba(15, 136, 197, 0.08), transparent 30%),
+    var(--color-bg, #0d1821);
+  box-sizing: border-box;
+}
+
+.access-report {
+  width: min(1180px, 100%);
   margin: 0 auto;
-  padding: 24px 16px 28px;
+  padding: 12px 8px 12px;
   color: var(--text-1, #f2f4f5);
   display: flex;
   flex-direction: column;
-  align-items: center;
   gap: 18px;
 }
 
@@ -17,6 +27,7 @@
   gap: 12px;
   align-items: center;
   width: 100%;
+  padding: 0 6px;
 }
 
 .access-report__eyebrow {
@@ -36,7 +47,7 @@
 .access-report__subtitle {
   margin: 4px 0 0;
   color: var(--text-2, #cfe3df);
-  max-width: 720px;
+  max-width: 780px;
   line-height: 1.4;
 }
 
@@ -63,6 +74,7 @@
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 12px;
   width: 100%;
+  padding: 0 6px;
 }
 
 .access-report__card {
@@ -122,6 +134,7 @@
   overflow: hidden;
   box-shadow: var(--shadow-soft, 0 6px 18px rgba(0, 0, 0, 0.22));
   width: 100%;
+  margin-top: 4px;
 }
 
 .access-report__table-header {

--- a/technomoney-app/src/components/AccessReport/AccessReport.css
+++ b/technomoney-app/src/components/AccessReport/AccessReport.css
@@ -1,11 +1,13 @@
 .access-report {
-  max-width: 1100px;
+  width: 100%;
+  max-width: 1180px;
   margin: 0 auto;
-  padding: 20px 16px 28px;
+  padding: 24px 16px 28px;
   color: var(--text-1, #f2f4f5);
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  align-items: center;
+  gap: 18px;
 }
 
 .access-report__header {
@@ -14,6 +16,7 @@
   justify-content: space-between;
   gap: 12px;
   align-items: center;
+  width: 100%;
 }
 
 .access-report__eyebrow {
@@ -59,6 +62,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 12px;
+  width: 100%;
 }
 
 .access-report__card {
@@ -117,6 +121,7 @@
   border-radius: 12px;
   overflow: hidden;
   box-shadow: var(--shadow-soft, 0 6px 18px rgba(0, 0, 0, 0.22));
+  width: 100%;
 }
 
 .access-report__table-header {

--- a/technomoney-app/src/components/AccessReport/AccessReport.css
+++ b/technomoney-app/src/components/AccessReport/AccessReport.css
@@ -1,35 +1,40 @@
 .access-report {
-  max-width: 1200px;
+  max-width: 1100px;
   margin: 0 auto;
-  padding: 32px 20px 48px;
-  color: #1b1b1b;
+  padding: 20px 16px 28px;
+  color: var(--text-1, #f2f4f5);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .access-report__header {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  gap: 16px;
-  align-items: flex-end;
+  gap: 12px;
+  align-items: center;
 }
 
 .access-report__eyebrow {
   text-transform: uppercase;
   letter-spacing: 1px;
   font-size: 12px;
-  color: #6b7280;
+  color: var(--text-2, #cfe3df);
   margin: 0 0 4px;
 }
 
 .access-report h1 {
   margin: 0;
-  font-size: 28px;
+  font-size: 24px;
+  color: var(--brand-primary, #0cb3a8);
 }
 
 .access-report__subtitle {
-  margin: 6px 0 0;
-  color: #4b5563;
+  margin: 4px 0 0;
+  color: var(--text-2, #cfe3df);
   max-width: 720px;
+  line-height: 1.4;
 }
 
 .access-report__month-picker {
@@ -37,119 +42,131 @@
   flex-direction: column;
   gap: 6px;
   font-weight: 600;
-  color: #374151;
+  color: var(--text-1, #f2f4f5);
 }
 
 .access-report__month-picker input {
   padding: 10px 12px;
-  border-radius: 8px;
-  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  border: 1px solid var(--border-soft, rgba(255, 255, 255, 0.12));
   min-width: 180px;
   font-size: 14px;
+  background: var(--surface-1, #10222b);
+  color: var(--text-1, #f2f4f5);
 }
 
 .access-report__summary {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
-  margin-top: 24px;
+  gap: 12px;
 }
 
 .access-report__card {
-  background: #f8fafc;
-  border: 1px solid #e5e7eb;
+  background: var(--surface-1, #10222b);
+  border: 1px solid var(--border-soft, rgba(255, 255, 255, 0.06));
   border-radius: 12px;
-  padding: 16px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.03);
+  padding: 14px;
+  box-shadow: var(--shadow-soft, 0 6px 18px rgba(0, 0, 0, 0.22));
   position: relative;
 }
 
 .access-report__card--info {
-  background: linear-gradient(135deg, #f7faff, #eef2ff);
+  background: var(--surface-2, #122a35);
 }
 
 .access-report__card-label {
   margin: 0;
-  color: #6b7280;
-  font-size: 13px;
+  color: var(--text-2, #cfe3df);
+  font-size: 12px;
+  letter-spacing: 0.2px;
 }
 
 .access-report__card-value {
   display: block;
-  font-size: 26px;
-  margin-top: 4px;
-  color: #111827;
+  font-size: 22px;
+  margin-top: 2px;
+  color: var(--text-1, #f2f4f5);
 }
 
 .access-report__card-value--muted {
-  font-size: 16px;
-  color: #1f2937;
+  font-size: 15px;
+  color: var(--text-2, #cfe3df);
   font-weight: 600;
 }
 
 .access-report__card-help {
-  margin: 6px 0 0;
-  color: #6b7280;
-  font-size: 13px;
+  margin: 4px 0 0;
+  color: var(--text-2, #cfe3df);
+  font-size: 12px;
 }
 
 .access-report__chip {
   display: inline-block;
-  padding: 6px 10px;
+  padding: 4px 8px;
   border-radius: 999px;
-  background: #1d4ed8;
-  color: white;
-  font-size: 12px;
-  margin-top: 10px;
+  background: var(--brand-primary, #0cb3a8);
+  color: #0d1821;
+  font-size: 11px;
+  margin-top: 6px;
+  font-weight: 700;
 }
 
 .access-report__table {
-  margin-top: 28px;
-  background: white;
-  border: 1px solid #e5e7eb;
+  background: var(--surface-1, #10222b);
+  border: 1px solid var(--border-soft, rgba(255, 255, 255, 0.06));
   border-radius: 12px;
   overflow: hidden;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+  box-shadow: var(--shadow-soft, 0 6px 18px rgba(0, 0, 0, 0.22));
 }
 
 .access-report__table-header {
-  padding: 16px 20px 8px;
-  border-bottom: 1px solid #e5e7eb;
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid var(--border-soft, rgba(255, 255, 255, 0.06));
 }
 
 .access-report__table-header h2 {
-  margin: 0 0 4px;
+  margin: 0 0 2px;
+  font-size: 18px;
+  color: var(--text-1, #f2f4f5);
 }
 
 .access-report__table-header p {
   margin: 0;
-  color: #6b7280;
+  color: var(--text-2, #cfe3df);
+  font-size: 13px;
 }
 
 .access-report__table-wrapper {
   overflow-x: auto;
+  max-height: 260px;
+  overflow-y: auto;
 }
 
 .access-report table {
   width: 100%;
   border-collapse: collapse;
+  color: var(--text-1, #f2f4f5);
 }
 
 .access-report th,
 .access-report td {
   text-align: left;
-  padding: 12px 16px;
-  border-bottom: 1px solid #e5e7eb;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-soft, rgba(255, 255, 255, 0.06));
+  font-size: 14px;
 }
 
 .access-report th {
-  background: #f9fafb;
-  color: #4b5563;
+  background: var(--surface-2, #122a35);
+  color: var(--text-1, #f2f4f5);
   font-weight: 600;
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 
 .access-report__revoked {
-  color: #b91c1c;
+  color: #f87171;
   font-weight: 600;
 }
 
@@ -159,7 +176,8 @@
   flex-direction: column;
   align-items: center;
   gap: 10px;
-  padding: 24px;
+  padding: 16px;
+  color: var(--text-1, #f2f4f5);
 }
 
 .access-report__error p {
@@ -167,8 +185,8 @@
 }
 
 .access-report__empty {
-  padding: 16px 20px;
-  color: #6b7280;
+  padding: 14px 16px;
+  color: var(--text-2, #cfe3df);
   margin: 0;
 }
 

--- a/technomoney-app/src/components/AccessReport/AccessReport.tsx
+++ b/technomoney-app/src/components/AccessReport/AccessReport.tsx
@@ -6,7 +6,7 @@ import type { MonthlyAccessReport } from "../../types/reports";
 import "./AccessReport.css";
 
 const now = new Date();
-const defaultMonth = now.toISOString().slice(0, 7);
+const defaultMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
 
 function formatMonthLabel(value: string): string {
   if (!/^\d{4}-\d{2}$/.test(value)) return "Mês atual";
@@ -14,6 +14,7 @@ function formatMonthLabel(value: string): string {
   return new Date(Date.UTC(year, month - 1, 1)).toLocaleDateString("pt-BR", {
     month: "long",
     year: "numeric",
+    timeZone: "UTC",
   });
 }
 
@@ -21,7 +22,13 @@ function formatDay(value: string): string {
   return new Date(`${value}T00:00:00Z`).toLocaleDateString("pt-BR", {
     day: "2-digit",
     month: "short",
+    timeZone: "UTC",
   });
+}
+
+function formatDate(value?: string): string | null {
+  if (!value) return null;
+  return new Date(value).toLocaleDateString("pt-BR", { timeZone: "UTC" });
 }
 
 export default function AccessReport() {
@@ -48,108 +55,109 @@ export default function AccessReport() {
   }, [data?.month, selectedMonth]);
 
   return (
-    <div className="access-report">
-      <div className="access-report__header">
-        <div>
-          <p className="access-report__eyebrow">Segurança</p>
-          <h1>Relatório mensal de acessos</h1>
-          <p className="access-report__subtitle">
-            Acompanhe o volume de sessões iniciadas e revogadas no mês selecionado. Os
-            números são calculados a partir da tabela de sessões do serviço de autenticação.
-          </p>
-        </div>
-        <label className="access-report__month-picker">
-          <span>Mês de referência</span>
-          <input
-            type="month"
-            value={selectedMonth}
-            onChange={(e) => setSelectedMonth(e.target.value)}
-            aria-label="Selecione o mês do relatório"
-          />
-        </label>
-      </div>
-
-      {isLoading || !enabled ? (
-        <div className="access-report__loading" role="status">
-          <Spinner />
-          <p>Montando o relatório...</p>
-        </div>
-      ) : isError ? (
-        <div className="access-report__error" role="alert">
-          <p>Não foi possível carregar o relatório agora.</p>
-          <button type="button" className="btn btn-primary" onClick={() => refetch()}>
-            Tentar novamente
-          </button>
-        </div>
-      ) : (
-        <>
-          <div className="access-report__summary">
-            <div className="access-report__card">
-              <p className="access-report__card-label">Mês</p>
-              <strong className="access-report__card-value">{monthLabel}</strong>
-            </div>
-            <div className="access-report__card">
-              <p className="access-report__card-label">Sessões criadas</p>
-              <strong className="access-report__card-value">
-                {totals.created.toLocaleString("pt-BR")}
-              </strong>
-              <p className="access-report__card-help">Somas de todas as sessões geradas no mês.</p>
-            </div>
-            <div className="access-report__card">
-              <p className="access-report__card-label">Sessões revogadas</p>
-              <strong className="access-report__card-value">
-                {totals.revoked.toLocaleString("pt-BR")}
-              </strong>
-              <p className="access-report__card-help">
-                Inclui expirações e revogações realizadas pelo usuário ou pelo sistema.
-              </p>
-            </div>
-            <div className="access-report__card access-report__card--info">
-              <p className="access-report__card-label">Janela analisada</p>
-              <p className="access-report__card-value access-report__card-value--muted">
-                {data?.period.start && new Date(data.period.start).toLocaleDateString("pt-BR")}
-                {" "}
-                até
-                {" "}
-                {data?.period.endExclusive &&
-                  new Date(new Date(data.period.endExclusive).getTime() - 1000)
-                    .toLocaleDateString("pt-BR")}
-              </p>
-              {isFetching && <span className="access-report__chip">Atualizando…</span>}
-            </div>
+    <main className="access-report-page">
+      <div className="access-report">
+        <div className="access-report__header">
+          <div>
+            <p className="access-report__eyebrow">Segurança</p>
+            <h1>Relatório mensal de acessos</h1>
+            <p className="access-report__subtitle">
+              Acompanhe o volume de sessões iniciadas e revogadas no mês selecionado. Os
+              números são calculados a partir da tabela de sessões do serviço de autenticação.
+            </p>
           </div>
+          <label className="access-report__month-picker">
+            <span>Mês de referência</span>
+            <input
+              type="month"
+              value={selectedMonth}
+              onChange={(e) => setSelectedMonth(e.target.value)}
+              aria-label="Selecione o mês do relatório"
+            />
+          </label>
+        </div>
 
-          <div className="access-report__table">
-            <div className="access-report__table-header">
-              <h2>Evolução diária</h2>
-              <p>Resumo consolidado por dia dentro do mês escolhido.</p>
+        {isLoading || !enabled ? (
+          <div className="access-report__loading" role="status">
+            <Spinner />
+            <p>Montando o relatório...</p>
+          </div>
+        ) : isError ? (
+          <div className="access-report__error" role="alert">
+            <p>Não foi possível carregar o relatório agora.</p>
+            <button type="button" className="btn btn-primary" onClick={() => refetch()}>
+              Tentar novamente
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="access-report__summary">
+              <div className="access-report__card">
+                <p className="access-report__card-label">Mês</p>
+                <strong className="access-report__card-value">{monthLabel}</strong>
+              </div>
+              <div className="access-report__card">
+                <p className="access-report__card-label">Sessões criadas</p>
+                <strong className="access-report__card-value">
+                  {totals.created.toLocaleString("pt-BR")}
+                </strong>
+                <p className="access-report__card-help">Somas de todas as sessões geradas no mês.</p>
+              </div>
+              <div className="access-report__card">
+                <p className="access-report__card-label">Sessões revogadas</p>
+                <strong className="access-report__card-value">
+                  {totals.revoked.toLocaleString("pt-BR")}
+                </strong>
+                <p className="access-report__card-help">
+                  Inclui expirações e revogações realizadas pelo usuário ou pelo sistema.
+                </p>
+              </div>
+              <div className="access-report__card access-report__card--info">
+                <p className="access-report__card-label">Janela analisada</p>
+                <p className="access-report__card-value access-report__card-value--muted">
+                  {formatDate(data?.period.start)} até {" "}
+                  {formatDate(
+                    data?.period.endExclusive
+                      ? new Date(new Date(data.period.endExclusive).getTime() - 1000).toISOString()
+                      : undefined
+                  )}
+                </p>
+                {isFetching && <span className="access-report__chip">Atualizando…</span>}
+              </div>
             </div>
-            <div className="access-report__table-wrapper">
-              <table>
-                <thead>
-                  <tr>
-                    <th>Dia</th>
-                    <th>Novas sessões</th>
-                    <th>Revogações</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {data?.daily.map((entry) => (
-                    <tr key={entry.day}>
-                      <td>{formatDay(entry.day)}</td>
-                      <td>{entry.created.toLocaleString("pt-BR")}</td>
-                      <td className="access-report__revoked">{entry.revoked.toLocaleString("pt-BR")}</td>
+
+            <div className="access-report__table">
+              <div className="access-report__table-header">
+                <h2>Evolução diária</h2>
+                <p>Resumo consolidado por dia dentro do mês escolhido.</p>
+              </div>
+              <div className="access-report__table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Dia</th>
+                      <th>Novas sessões</th>
+                      <th>Revogações</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody>
+                    {data?.daily.map((entry) => (
+                      <tr key={entry.day}>
+                        <td>{formatDay(entry.day)}</td>
+                        <td>{entry.created.toLocaleString("pt-BR")}</td>
+                        <td className="access-report__revoked">{entry.revoked.toLocaleString("pt-BR")}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              {data && data.daily.every((d) => d.created === 0 && d.revoked === 0) && (
+                <p className="access-report__empty">Nenhum acesso registrado para este mês.</p>
+              )}
             </div>
-            {data && data.daily.every((d) => d.created === 0 && d.revoked === 0) && (
-              <p className="access-report__empty">Nenhum acesso registrado para este mês.</p>
-            )}
-          </div>
-        </>
-      )}
-    </div>
+          </>
+        )}
+      </div>
+    </main>
   );
 }

--- a/technomoney-app/src/components/AccessReport/AccessReport.tsx
+++ b/technomoney-app/src/components/AccessReport/AccessReport.tsx
@@ -42,6 +42,11 @@ export default function AccessReport() {
     [data?.totals]
   );
 
+  const monthLabel = useMemo(() => {
+    if (data?.month) return formatMonthLabel(data.month);
+    return formatMonthLabel(selectedMonth);
+  }, [data?.month, selectedMonth]);
+
   return (
     <div className="access-report">
       <div className="access-report__header">
@@ -81,7 +86,7 @@ export default function AccessReport() {
           <div className="access-report__summary">
             <div className="access-report__card">
               <p className="access-report__card-label">Mês</p>
-              <strong className="access-report__card-value">{formatMonthLabel(selectedMonth)}</strong>
+              <strong className="access-report__card-value">{monthLabel}</strong>
             </div>
             <div className="access-report__card">
               <p className="access-report__card-label">Sessões criadas</p>

--- a/technomoney-app/src/components/AccessReport/AccessReport.tsx
+++ b/technomoney-app/src/components/AccessReport/AccessReport.tsx
@@ -1,0 +1,150 @@
+import React, { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import Spinner from "../Spinner/Spinner";
+import { fetchMonthlyAccessReport } from "../../services/reports";
+import type { MonthlyAccessReport } from "../../types/reports";
+import "./AccessReport.css";
+
+const now = new Date();
+const defaultMonth = now.toISOString().slice(0, 7);
+
+function formatMonthLabel(value: string): string {
+  if (!/^\d{4}-\d{2}$/.test(value)) return "Mês atual";
+  const [year, month] = value.split("-").map((v) => parseInt(v, 10));
+  return new Date(Date.UTC(year, month - 1, 1)).toLocaleDateString("pt-BR", {
+    month: "long",
+    year: "numeric",
+  });
+}
+
+function formatDay(value: string): string {
+  return new Date(`${value}T00:00:00Z`).toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "short",
+  });
+}
+
+export default function AccessReport() {
+  const [selectedMonth, setSelectedMonth] = useState(defaultMonth);
+  const enabled = /^\d{4}-\d{2}$/.test(selectedMonth);
+
+  const { data, isLoading, isError, refetch, isFetching } = useQuery<MonthlyAccessReport>({
+    queryKey: ["monthly-access-report", selectedMonth],
+    queryFn: () => fetchMonthlyAccessReport(selectedMonth),
+    enabled,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 15 * 60 * 1000,
+    keepPreviousData: true,
+  });
+
+  const totals = useMemo(
+    () => data?.totals ?? { created: 0, revoked: 0 },
+    [data?.totals]
+  );
+
+  return (
+    <div className="access-report">
+      <div className="access-report__header">
+        <div>
+          <p className="access-report__eyebrow">Segurança</p>
+          <h1>Relatório mensal de acessos</h1>
+          <p className="access-report__subtitle">
+            Acompanhe o volume de sessões iniciadas e revogadas no mês selecionado. Os
+            números são calculados a partir da tabela de sessões do serviço de autenticação.
+          </p>
+        </div>
+        <label className="access-report__month-picker">
+          <span>Mês de referência</span>
+          <input
+            type="month"
+            value={selectedMonth}
+            onChange={(e) => setSelectedMonth(e.target.value)}
+            aria-label="Selecione o mês do relatório"
+          />
+        </label>
+      </div>
+
+      {isLoading || !enabled ? (
+        <div className="access-report__loading" role="status">
+          <Spinner />
+          <p>Montando o relatório...</p>
+        </div>
+      ) : isError ? (
+        <div className="access-report__error" role="alert">
+          <p>Não foi possível carregar o relatório agora.</p>
+          <button type="button" className="btn btn-primary" onClick={() => refetch()}>
+            Tentar novamente
+          </button>
+        </div>
+      ) : (
+        <>
+          <div className="access-report__summary">
+            <div className="access-report__card">
+              <p className="access-report__card-label">Mês</p>
+              <strong className="access-report__card-value">{formatMonthLabel(selectedMonth)}</strong>
+            </div>
+            <div className="access-report__card">
+              <p className="access-report__card-label">Sessões criadas</p>
+              <strong className="access-report__card-value">
+                {totals.created.toLocaleString("pt-BR")}
+              </strong>
+              <p className="access-report__card-help">Somas de todas as sessões geradas no mês.</p>
+            </div>
+            <div className="access-report__card">
+              <p className="access-report__card-label">Sessões revogadas</p>
+              <strong className="access-report__card-value">
+                {totals.revoked.toLocaleString("pt-BR")}
+              </strong>
+              <p className="access-report__card-help">
+                Inclui expirações e revogações realizadas pelo usuário ou pelo sistema.
+              </p>
+            </div>
+            <div className="access-report__card access-report__card--info">
+              <p className="access-report__card-label">Janela analisada</p>
+              <p className="access-report__card-value access-report__card-value--muted">
+                {data?.period.start && new Date(data.period.start).toLocaleDateString("pt-BR")}
+                {" "}
+                até
+                {" "}
+                {data?.period.endExclusive &&
+                  new Date(new Date(data.period.endExclusive).getTime() - 1000)
+                    .toLocaleDateString("pt-BR")}
+              </p>
+              {isFetching && <span className="access-report__chip">Atualizando…</span>}
+            </div>
+          </div>
+
+          <div className="access-report__table">
+            <div className="access-report__table-header">
+              <h2>Evolução diária</h2>
+              <p>Resumo consolidado por dia dentro do mês escolhido.</p>
+            </div>
+            <div className="access-report__table-wrapper">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Dia</th>
+                    <th>Novas sessões</th>
+                    <th>Revogações</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data?.daily.map((entry) => (
+                    <tr key={entry.day}>
+                      <td>{formatDay(entry.day)}</td>
+                      <td>{entry.created.toLocaleString("pt-BR")}</td>
+                      <td className="access-report__revoked">{entry.revoked.toLocaleString("pt-BR")}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {data && data.daily.every((d) => d.created === 0 && d.revoked === 0) && (
+              <p className="access-report__empty">Nenhum acesso registrado para este mês.</p>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/technomoney-app/src/components/Menu/Menu.tsx
+++ b/technomoney-app/src/components/Menu/Menu.tsx
@@ -8,6 +8,7 @@ import {
   faPhone,
   faNewspaper,
   faQuestionCircle,
+  faChartColumn,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import "./Menu.css";
@@ -74,6 +75,12 @@ const Menu: React.FC<MenuProps> = ({ onClose }) => {
               <a href="/#blog" onClick={onClose}>
                 <FontAwesomeIcon icon={faNewspaper} style={{ marginRight: 8 }} />
                 Blog / Notícias
+              </a>
+            </li>
+            <li>
+              <a href="/access-report" onClick={onClose}>
+                <FontAwesomeIcon icon={faChartColumn} style={{ marginRight: 8 }} />
+                Relatório de acessos
               </a>
             </li>
             <li>

--- a/technomoney-app/src/services/reports.ts
+++ b/technomoney-app/src/services/reports.ts
@@ -1,0 +1,10 @@
+import { authApi } from "./http";
+import type { MonthlyAccessReport } from "../types/reports";
+
+export async function fetchMonthlyAccessReport(month: string): Promise<MonthlyAccessReport> {
+  const params = month ? { month } : undefined;
+  const { data } = await authApi.get<MonthlyAccessReport>("/auth/reports/monthly-access", {
+    params,
+  });
+  return data;
+}

--- a/technomoney-app/src/types/reports.ts
+++ b/technomoney-app/src/types/reports.ts
@@ -1,0 +1,18 @@
+export interface DailyAccessEntry {
+  day: string;
+  created: number;
+  revoked: number;
+}
+
+export interface MonthlyAccessReport {
+  month: string;
+  period: {
+    start: string;
+    endExclusive: string;
+  };
+  totals: {
+    created: number;
+    revoked: number;
+  };
+  daily: DailyAccessEntry[];
+}

--- a/technomoney-auth/src/controllers/reports.controller.ts
+++ b/technomoney-auth/src/controllers/reports.controller.ts
@@ -24,7 +24,7 @@ export const monthlyAccessReport: RequestHandler = async (req, res) => {
       res.status(400).json({ error: "INVALID_MONTH", message: "Use o formato YYYY-MM." });
       return;
     }
-    logger.error({ ...getLogContext(req), err }, "reports.monthly_access.error");
+    logger.error({ ...getLogContext(), err }, "reports.monthly_access.error");
     res.status(500).json({ error: "REPORT_GENERATION_FAILED" });
   }
 };

--- a/technomoney-auth/src/controllers/reports.controller.ts
+++ b/technomoney-auth/src/controllers/reports.controller.ts
@@ -1,0 +1,30 @@
+import { RequestHandler } from "express";
+import { ReportService } from "../services/report.service";
+import { logger } from "../utils/log/logger";
+import { getLogContext } from "../utils/log/logging-context";
+
+let reportService: ReportService = new ReportService();
+
+export const __setReportsControllerDeps = (deps: { reportService?: ReportService }) => {
+  if (deps.reportService) reportService = deps.reportService;
+};
+
+export const __resetReportsControllerDeps = () => {
+  reportService = new ReportService();
+};
+
+export const monthlyAccessReport: RequestHandler = async (req, res) => {
+  try {
+    const month = typeof req.query?.month === "string" ? req.query.month : undefined;
+    const report = await reportService.monthlyAccessReport(month);
+    res.json(report);
+  } catch (err: any) {
+    const code = typeof err?.code === "string" ? err.code : "REPORT_ERROR";
+    if (code === "INVALID_MONTH") {
+      res.status(400).json({ error: "INVALID_MONTH", message: "Use o formato YYYY-MM." });
+      return;
+    }
+    logger.error({ ...getLogContext(req), err }, "reports.monthly_access.error");
+    res.status(500).json({ error: "REPORT_GENERATION_FAILED" });
+  }
+};

--- a/technomoney-auth/src/repositories/session.repository.ts
+++ b/technomoney-auth/src/repositories/session.repository.ts
@@ -1,5 +1,11 @@
-import { Transaction } from "sequelize";
+import { Transaction, Op, fn, col, literal } from "sequelize";
 import { Session } from "../models";
+
+export interface SessionDailyCount {
+  day: string;
+  created: number;
+  revoked: number;
+}
 
 export class SessionRepository {
   create(
@@ -52,5 +58,26 @@ export class SessionRepository {
       where: { sid: sid.trim(), revoked: false },
     });
     return !!session;
+  }
+
+  async getDailyAccessCounts(start: Date, end: Date): Promise<SessionDailyCount[]> {
+    const dayTrunc = fn("date_trunc", "day", col("created_at"));
+    const rows = await Session.findAll({
+      attributes: [
+        [dayTrunc, "day"],
+        [fn("COUNT", col("sid")), "created"],
+        [fn("SUM", literal("CASE WHEN revoked THEN 1 ELSE 0 END")), "revoked"],
+      ],
+      where: { created_at: { [Op.gte]: start, [Op.lt]: end } },
+      group: [dayTrunc],
+      order: [[dayTrunc, "ASC"]],
+      raw: true,
+    });
+
+    return rows.map((row: any) => ({
+      day: new Date(row.day).toISOString().slice(0, 10),
+      created: Number(row.created) || 0,
+      revoked: Number(row.revoked) || 0,
+    }));
   }
 }

--- a/technomoney-auth/src/routes/auth.routes.ts
+++ b/technomoney-auth/src/routes/auth.routes.ts
@@ -20,6 +20,7 @@ import { authenticate, requireFullSession } from "../middlewares/auth.middleware
 import { enforcePasswordPolicy } from "../middlewares/passwordPolicy.middleware";
 import { csrfProtection } from "../middlewares/csrf.middleware";
 import { wsTicket } from "../controllers/ws.controller";
+import { monthlyAccessReport } from "../controllers/reports.controller";
 
 const router = Router();
 
@@ -61,6 +62,12 @@ router.post(
   recoveryLimiter,
   csrfProtection,
   confirmEmailVerification
+);
+router.get(
+  "/reports/monthly-access",
+  authenticate,
+  requireFullSession,
+  monthlyAccessReport
 );
 
 const csrfGet: RequestHandler = (req: any, res) => {

--- a/technomoney-auth/src/services/report.service.ts
+++ b/technomoney-auth/src/services/report.service.ts
@@ -1,0 +1,84 @@
+import { SessionRepository, SessionDailyCount } from "../repositories/session.repository";
+
+export interface MonthlyAccessReport {
+  month: string;
+  period: {
+    start: string;
+    endExclusive: string;
+  };
+  totals: {
+    created: number;
+    revoked: number;
+  };
+  daily: SessionDailyCount[];
+}
+
+export class ReportService {
+  private sessionRepo: SessionRepository;
+
+  constructor(sessionRepo = new SessionRepository()) {
+    this.sessionRepo = sessionRepo;
+  }
+
+  async monthlyAccessReport(monthInput?: string): Promise<MonthlyAccessReport> {
+    const { start, end, year, month } = this.resolveMonth(monthInput);
+    const rows = await this.sessionRepo.getDailyAccessCounts(start, end);
+    const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+    const byDate = new Map(rows.map((row) => [row.day, row]));
+
+    const daily: SessionDailyCount[] = [];
+    for (let day = 1; day <= daysInMonth; day++) {
+      const date = new Date(Date.UTC(year, month, day)).toISOString().slice(0, 10);
+      const existing = byDate.get(date);
+      daily.push({
+        day: date,
+        created: existing?.created ?? 0,
+        revoked: existing?.revoked ?? 0,
+      });
+    }
+
+    const totals = daily.reduce(
+      (acc, cur) => {
+        acc.created += cur.created;
+        acc.revoked += cur.revoked;
+        return acc;
+      },
+      { created: 0, revoked: 0 }
+    );
+
+    return {
+      month: `${year}-${String(month + 1).padStart(2, "0")}`,
+      period: {
+        start: start.toISOString(),
+        endExclusive: end.toISOString(),
+      },
+      totals,
+      daily,
+    };
+  }
+
+  private resolveMonth(monthInput?: string) {
+    if (monthInput && !/^\d{4}-\d{2}$/.test(monthInput)) {
+      const err = new Error("INVALID_MONTH");
+      (err as any).code = "INVALID_MONTH";
+      throw err;
+    }
+
+    const [year, month] = monthInput
+      ? monthInput.split("-").map((n) => parseInt(n, 10))
+      : [undefined, undefined];
+    const resolvedYear = Number.isFinite(year) ? (year as number) : new Date().getUTCFullYear();
+    const resolvedMonth = Number.isFinite(month) ? (month as number) - 1 : new Date().getUTCMonth();
+
+    if (resolvedMonth < 0 || resolvedMonth > 11) {
+      const err = new Error("INVALID_MONTH");
+      (err as any).code = "INVALID_MONTH";
+      throw err;
+    }
+
+    const start = new Date(Date.UTC(resolvedYear, resolvedMonth, 1));
+    const end = new Date(Date.UTC(resolvedYear, resolvedMonth + 1, 1));
+
+    return { start, end, year: resolvedYear, month: resolvedMonth };
+  }
+}


### PR DESCRIPTION
## Summary
- add backend report endpoint that aggregates session activity by day for a selected month
- build frontend access report page with month selector, summary cards, and daily table
- link the new report route into the authenticated navigation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e38390f8c8327b060e8bf215d0f3b)